### PR TITLE
Exposures by default

### DIFF
--- a/metric_config_parser/metric.py
+++ b/metric_config_parser/metric.py
@@ -174,7 +174,7 @@ class MetricDefinition:
                     f"No default definition found for referenced metric {self.name}"
                 )
 
-            metric_definition.analysis_bases = self.analysis_bases or [AnalysisBasis.ENROLLMENTS]
+            metric_definition.analysis_bases = self.analysis_bases or [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES]
             metric_definition.statistics = self.statistics
             metric_summary = metric_definition.resolve(spec, conf, configs)
         else:
@@ -193,7 +193,7 @@ class MetricDefinition:
                 else self.friendly_name,
                 description=dedent(self.description) if self.description else self.description,
                 bigger_is_better=self.bigger_is_better,
-                analysis_bases=self.analysis_bases or [AnalysisBasis.ENROLLMENTS],
+                analysis_bases=self.analysis_bases or [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES],
                 type=self.type or "scalar",
                 category=self.category,
             )

--- a/metric_config_parser/metric.py
+++ b/metric_config_parser/metric.py
@@ -176,7 +176,7 @@ class MetricDefinition:
 
             metric_definition.analysis_bases = self.analysis_bases or [
                 AnalysisBasis.ENROLLMENTS,
-                AnalysisBasis.EXPOSURES
+                AnalysisBasis.EXPOSURES,
             ]
             metric_definition.statistics = self.statistics
             metric_summary = metric_definition.resolve(spec, conf, configs)

--- a/metric_config_parser/metric.py
+++ b/metric_config_parser/metric.py
@@ -174,7 +174,10 @@ class MetricDefinition:
                     f"No default definition found for referenced metric {self.name}"
                 )
 
-            metric_definition.analysis_bases = self.analysis_bases or [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES]
+            metric_definition.analysis_bases = self.analysis_bases or [
+                AnalysisBasis.ENROLLMENTS,
+                AnalysisBasis.EXPOSURES
+            ]
             metric_definition.statistics = self.statistics
             metric_summary = metric_definition.resolve(spec, conf, configs)
         else:
@@ -193,7 +196,8 @@ class MetricDefinition:
                 else self.friendly_name,
                 description=dedent(self.description) if self.description else self.description,
                 bigger_is_better=self.bigger_is_better,
-                analysis_bases=self.analysis_bases or [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES],
+                analysis_bases=self.analysis_bases
+                or [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES],
                 type=self.type or "scalar",
                 category=self.category,
             )

--- a/metric_config_parser/tests/test_analysis.py
+++ b/metric_config_parser/tests/test_analysis.py
@@ -317,7 +317,7 @@ class TestAnalysisSpec:
         assert len(cfg.metrics[AnalysisPeriod.WEEK]) == 1
         assert spam.metric.data_source.name == "main"
         assert spam.metric.select_expression == "2"
-        assert spam.metric.analysis_bases == [AnalysisBasis.ENROLLMENTS]
+        assert spam.metric.analysis_bases == [AnalysisBasis.ENROLLMENTS, AnalysisBasis.EXPOSURES]
         assert spam.statistic.name == "bootstrap_mean"
         assert spam.statistic.params["num_samples"] == 100
 
@@ -341,6 +341,7 @@ class TestAnalysisSpec:
         metric = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"][0].metric
 
         assert AnalysisBasis.EXPOSURES in metric.analysis_bases
+        assert AnalysisBasis.ENROLLMENTS not in metric.analysis_bases
 
     def test_exposure_and_enrollments_based_metric(self, experiments, config_collection):
         config_str = dedent(

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2022.11.5",
+    version="2022.12.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2022.12.0",
+    version="2022.12.1",
 )


### PR DESCRIPTION
#114 only set default on the `Metric` class, where it's actually needed in the `MetricDefinition` class as well to really set the default properly. This PR addresses that and also updates tests to reflect the change in default behavior.

Also bumping version in `setup.py` to `2022.12.0` in anticipation of pushing a new version tag.