### PR TITLE
Add SQL generation for metrics

### DIFF
--- a/metric_config_parser/config.py
+++ b/metric_config_parser/config.py
@@ -22,6 +22,7 @@ from .errors import UnexpectedKeyConfigurationException
 from .experiment import Channel, Experiment
 from .metric import MetricDefinition
 from .outcome import OutcomeSpec
+from .sql import generate_metrics_sql
 from .util import TemporaryDirectory
 
 OUTCOMES_DIR = "outcomes"
@@ -511,6 +512,18 @@ class ConfigCollection:
                             return segment
 
         return None
+
+    def get_metrics_sql(
+        self,
+        metrics: List[str],
+        platform: str,
+        group_by: List[str] = [],
+        where: Optional[str] = None,
+    ):
+        """Generate a SQL query for the specified metrics."""
+        return generate_metrics_sql(
+            self, metrics=metrics, platform=platform, group_by=group_by, where=where
+        )
 
     def get_env(self) -> jinja2.Environment:
         """

--- a/metric_config_parser/config.py
+++ b/metric_config_parser/config.py
@@ -519,10 +519,18 @@ class ConfigCollection:
         platform: str,
         group_by: List[str] = [],
         where: Optional[str] = None,
+        group_by_client_id: bool = True,
+        group_by_submission_date: bool = True,
     ) -> str:
         """Generate a SQL query for the specified metrics."""
         return generate_metrics_sql(
-            self, metrics=metrics, platform=platform, group_by=group_by, where=where
+            self,
+            metrics=metrics,
+            platform=platform,
+            group_by=group_by,
+            where=where,
+            group_by_client_id=group_by_client_id,
+            group_by_submission_date=group_by_submission_date,
         )
 
     def get_data_source_sql(

--- a/metric_config_parser/config.py
+++ b/metric_config_parser/config.py
@@ -22,7 +22,7 @@ from .errors import UnexpectedKeyConfigurationException
 from .experiment import Channel, Experiment
 from .metric import MetricDefinition
 from .outcome import OutcomeSpec
-from .sql import generate_metrics_sql
+from .sql import generate_data_source_sql, generate_metrics_sql
 from .util import TemporaryDirectory
 
 OUTCOMES_DIR = "outcomes"
@@ -519,10 +519,17 @@ class ConfigCollection:
         platform: str,
         group_by: List[str] = [],
         where: Optional[str] = None,
-    ):
+    ) -> str:
         """Generate a SQL query for the specified metrics."""
         return generate_metrics_sql(
             self, metrics=metrics, platform=platform, group_by=group_by, where=where
+        )
+
+    def get_data_source_sql(
+        self, data_source: str, platform: str, where: Optional[str] = None
+    ) -> str:
+        return generate_data_source_sql(
+            self, data_source=data_source, platform=platform, where=where
         )
 
     def get_env(self) -> jinja2.Environment:

--- a/metric_config_parser/sql.py
+++ b/metric_config_parser/sql.py
@@ -18,6 +18,8 @@ def generate_metrics_sql(
     platform: str,
     group_by: Union[List[str], Dict[str, str]] = [],
     where: Optional[str] = None,
+    group_by_client_id: bool = True,
+    group_by_submission_date: bool = True,
 ) -> str:
     """Generates a SQL query for metrics and specified parameters."""
     metric_definitions: List[MetricDefinition] = []
@@ -77,6 +79,8 @@ def generate_metrics_sql(
                 "metrics_per_data_source": metrics_per_data_source,
                 "where": where,
                 "group_by": group_by,
+                "group_by_client_id": group_by_client_id,
+                "group_by_submission_date": group_by_submission_date,
             }
         )
     )

--- a/metric_config_parser/sql.py
+++ b/metric_config_parser/sql.py
@@ -1,0 +1,81 @@
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from .metric import MetricDefinition
+
+if TYPE_CHECKING:
+    from .config import ConfigCollection
+
+FILE_PATH = Path(os.path.dirname(__file__))
+METRICS_QUERY = FILE_PATH / "templates" / "metrics_query.sql"
+
+
+def generate_metrics_sql(
+    config_collection: "ConfigCollection",
+    metrics: List[str],
+    platform: str,
+    group_by: Union[List[str], Dict[str, str]] = [],
+    where: Optional[str] = None,
+):
+    """Generates a SQL query for metrics and specified parameters."""
+    metric_definitions: List[MetricDefinition] = []
+    for slug in metrics:
+        definition = config_collection.get_metric_definition(slug, platform)
+
+        if definition is None:
+            raise ValueError(f"No definition for metric {slug} on platform {platform} found.")
+
+        metric_definitions.append(definition)
+
+    metrics_per_data_source: Dict[str, Any] = {}
+    for metric in metric_definitions:
+        if metric.select_expression is None:
+            raise ValueError(f"No definition for metric {metric.name}")
+
+        metric.select_expression = (
+            config_collection.get_env().from_string(metric.select_expression).render()
+        )
+
+        if metric.data_source is None:
+            raise ValueError(f"No data source for metric {metric.name}")
+
+        if metric.data_source.name in metrics_per_data_source:
+            metrics_per_data_source[metric.data_source.name]["metrics"].append(metric)
+        else:
+            data_source = config_collection.get_data_source_definition(
+                metric.data_source.name, platform
+            )
+
+            if data_source is None:
+                raise ValueError(f"No valid data source definition found for metric {metric.name}")
+
+            # default parameters need to be set explicitly otherwise they'll be None
+            data_source.client_id_column = data_source.client_id_column or "client_id"
+            data_source.submission_date_column = (
+                data_source.submission_date_column or "submission_date"
+            )
+
+            metrics_per_data_source[metric.data_source.name] = {
+                "data_source": data_source,
+                "metrics": [metric],
+            }
+
+    # group by should be a dictionary with the key being the alias and
+    # the value the potentially nested field;
+    # it can also be specified as list if all fields are top-level fields that don't need an alias
+    if isinstance(group_by, list):
+        group_by = {g: g for g in group_by}
+
+    template = METRICS_QUERY.read_text()
+    return (
+        config_collection.get_env()
+        .from_string(template)
+        .render(
+            **{
+                "metrics_per_data_source": metrics_per_data_source,
+                "where": where,
+                "group_by": group_by,
+            }
+        )
+    )

--- a/metric_config_parser/templates/data_source_query.sql
+++ b/metric_config_parser/templates/data_source_query.sql
@@ -1,0 +1,10 @@
+(
+    SELECT
+        *
+    FROM
+        ({{ data_source.from_expression }})
+    {% if where -%}
+    WHERE
+        {{ where }}
+    {% endif -%}
+)

--- a/metric_config_parser/templates/metrics_query.sql
+++ b/metric_config_parser/templates/metrics_query.sql
@@ -1,0 +1,53 @@
+(
+{% for data_source_slug, data_source_info in metrics_per_data_source.items() -%}
+{{ "WITH" if loop.first else "" }} {{ data_source_slug }} AS (
+    SELECT
+        {{ data_source_info["data_source"].client_id_column }} AS client_id,
+        {{ data_source_info["data_source"].submission_date_column }} AS submission_date,
+        {% for dimension, dimension_sql in group_by.items() -%}
+        {{ dimension_sql }} AS {{ dimension }},
+        {% endfor -%}
+        {% for metric in data_source_info["metrics"] -%}
+        {{ metric.select_expression }} AS {{ metric.name }},
+        {% endfor %}
+    FROM
+        {{ data_source_info["data_source"].from_expression }}
+    {% if where -%}
+    WHERE
+        {{ where }}
+    {% endif -%}
+    GROUP BY    
+        {% for dimension, dimension_sql in group_by.items() -%}
+        {{ dimension }},
+        {% endfor -%}
+        client_id,
+        submission_date
+){{ "," if not loop.last else "" }}
+{% endfor -%}
+
+{% for data_source_slug, data_source_info in metrics_per_data_source.items() -%}
+{% if loop.first -%}
+SELECT
+    {{ metrics_per_data_source.keys() | first }}.client_id,
+    {{ metrics_per_data_source.keys() | first }}.submission_date,
+    {% for dimension, dimension_sql in group_by.items() -%}
+    {{ metrics_per_data_source.keys() | first }}.{{ dimension_sql }} AS {{ dimension }},
+    {% endfor -%}
+    {% for d, data_source_info in metrics_per_data_source.items() -%}
+    {% for metric in data_source_info["metrics"] -%}
+    {{ metric.name }},
+    {% endfor -%}
+    {% endfor %}
+FROM
+    {{ metrics_per_data_source.keys() | first }}
+{% else -%}
+    FULL OUTER JOIN {{ data_source_slug }}
+    ON
+        {{ data_source_slug }}.submission_date = {{ metrics_per_data_source.keys() | first }}.submission_date AND
+        {{ data_source_slug }}.client_id = {{ metrics_per_data_source.keys() | first }}.client_id 
+        {% for dimension, dimension_sql in group_by.items() -%}
+        AND {{ data_source_slug }}.{{ dimension }} = {{ metrics_per_data_source.keys() | first }}.{{ dimension }} 
+        {% endfor -%}
+{% endif -%}
+{% endfor -%}
+)

--- a/metric_config_parser/templates/metrics_query.sql
+++ b/metric_config_parser/templates/metrics_query.sql
@@ -2,8 +2,12 @@
 {% for data_source_slug, data_source_info in metrics_per_data_source.items() -%}
 {{ "WITH" if loop.first else "" }} {{ data_source_slug }} AS (
     SELECT
+        {% if group_by_client_id -%}
         {{ data_source_info["data_source"].client_id_column }} AS client_id,
+        {% endif -%}
+        {% if group_by_submission_date -%}
         {{ data_source_info["data_source"].submission_date_column }} AS submission_date,
+        {% endif -%}
         {% for dimension, dimension_sql in group_by.items() -%}
         {{ dimension_sql }} AS {{ dimension }},
         {% endfor -%}
@@ -18,18 +22,26 @@
     {% endif -%}
     GROUP BY    
         {% for dimension, dimension_sql in group_by.items() -%}
-        {{ dimension }},
+        {{ dimension }}{{ "," if not loop.last or group_by_submission_date or group_by_client_id else "" }}
         {% endfor -%}
-        client_id,
+        {% if group_by_client_id -%}
+        client_id{{ "," if group_by_submission_date else "" }}
+        {% endif -%}
+        {% if group_by_submission_date -%}
         submission_date
+        {% endif %}
 ){{ "," if not loop.last else "" }}
 {% endfor -%}
 
 {% for data_source_slug, data_source_info in metrics_per_data_source.items() -%}
 {% if loop.first -%}
 SELECT
+    {% if group_by_client_id -%}
     {{ metrics_per_data_source.keys() | first }}.client_id,
+    {% endif -%}
+    {% if group_by_submission_date -%}
     {{ metrics_per_data_source.keys() | first }}.submission_date,
+    {% endif -%}
     {% for dimension, dimension_sql in group_by.items() -%}
     {{ metrics_per_data_source.keys() | first }}.{{ dimension_sql }} AS {{ dimension }},
     {% endfor -%}
@@ -43,8 +55,12 @@ FROM
 {% else -%}
     FULL OUTER JOIN {{ data_source_slug }}
     ON
+        {% if group_by_submission_date -%}
         {{ data_source_slug }}.submission_date = {{ metrics_per_data_source.keys() | first }}.submission_date AND
+        {% endif -%}
+        {% if group_by_client_id -%}
         {{ data_source_slug }}.client_id = {{ metrics_per_data_source.keys() | first }}.client_id 
+        {% endif -%}
         {% for dimension, dimension_sql in group_by.items() -%}
         AND {{ data_source_slug }}.{{ dimension }} = {{ metrics_per_data_source.keys() | first }}.{{ dimension }} 
         {% endfor -%}

--- a/metric_config_parser/tests/conftest.py
+++ b/metric_config_parser/tests/conftest.py
@@ -1,196 +1,15 @@
 import datetime as dt
 import shutil
 from pathlib import Path
-from textwrap import dedent
 
 import pytest
 import pytz
-import toml
 from git import Repo
 
-from metric_config_parser.analysis import AnalysisSpec
-from metric_config_parser.config import ConfigCollection, DefinitionConfig, Outcome
+from metric_config_parser.config import ConfigCollection
 from metric_config_parser.experiment import Branch, Experiment
-from metric_config_parser.function import FunctionsSpec
-from metric_config_parser.outcome import OutcomeSpec
 
 TEST_DIR = Path(__file__).parent
-
-
-@pytest.fixture
-def config_collection():
-    config_str = dedent(
-        """
-        [metrics]
-
-        [metrics.view_about_logins]
-        data_source = "main"
-        select_expression = "1"
-
-        [metrics.view_about_logins.statistics.bootstrap_mean]
-
-        [metrics.unenroll]
-        data_source = "main"
-        select_expression = "1"
-
-        [metrics.unenroll.statistics.bootstrap_mean]
-
-        [metrics.active_hours]
-        data_source = "main"
-        select_expression = "1"
-
-        [metrics.active_hours.statistics.bootstrap_mean]
-
-        [data_sources]
-
-        [data_sources.main]
-        from_expression = "SELECT 1"
-
-        [data_sources.clients_daily]
-        from_expression = "SELECT 1"
-
-        [segments]
-
-        [segments.regular_users_v3]
-        data_source = "my_cool_data_source"
-        select_expression = "{{agg_any('1')}}"
-
-        [segments.data_sources.my_cool_data_source]
-        from_expression = '''
-            (SELECT 1 WHERE submission_date BETWEEN {{experiment.start_date_str}}
-            AND {{experiment.last_enrollment_date_str}})
-        '''
-        """
-    )
-
-    performance_config = dedent(
-        """
-        friendly_name = "Performance outcomes"
-        description = "Outcomes related to performance"
-        default_metrics = ["speed"]
-
-        [metrics.speed]
-        data_source = "main"
-        select_expression = "1"
-
-        [metrics.speed.statistics.bootstrap_mean]
-        """
-    )
-
-    tastiness_config = dedent(
-        """
-        friendly_name = "Tastiness outcomes"
-        description = "Outcomes related to tastiness 😋"
-
-        [metrics.meals_eaten]
-        data_source = "meals"
-        select_expression = "1"
-        friendly_name = "Meals eaten"
-        description = "Number of consumed meals"
-
-        [metrics.meals_eaten.statistics.bootstrap_mean]
-        num_samples = 10
-        pre_treatments = ["remove_nulls"]
-
-        [data_sources.meals]
-        from_expression = "meals"
-        client_id_column = "client_info.client_id"
-        """
-    )
-
-    parameterized_config = dedent(
-        """
-        friendly_name = "Outcome with parameter same across all branches"
-        description = "Outcome that has a parameter that is the same across all branches"
-        default_metrics = ["sample_id_count"]
-
-        [metrics.sample_id_count]
-        data_source = "main"
-        select_expression = "COUNTIF(sample_id = {{ parameters.id }})"
-
-        [metrics.sample_id_count.statistics.bootstrap_mean]
-
-        [parameters.id]
-        friendly_name = "Some random ID"
-        description = "A random ID used to count samples"
-        default = "700"
-        distinct_by_branch = false
-        """
-    )
-
-    parameterized_distinct_by_branch_config = dedent(
-        """
-        friendly_name = "Outcome with parameter same across all branches"
-        description = "Outcome that has a parameter that is the same across all branches"
-        default_metrics = ["sample_id_count"]
-
-        [metrics.sample_id_count]
-        data_source = "main"
-        select_expression = "COUNTIF(sample_id = {{ parameters.id }})"
-
-        [metrics.sample_id_count.statistics.bootstrap_mean]
-
-        [parameters.id]
-        friendly_name = "Some random ID"
-        description = "A random ID used to count samples"
-        distinct_by_branch = true
-
-        default.branch_1 = 1
-        """
-    )
-
-    return ConfigCollection(
-        configs=[],
-        outcomes=[
-            Outcome(
-                slug="performance",
-                spec=OutcomeSpec.from_dict(toml.loads(performance_config)),
-                platform="firefox_desktop",
-                commit_hash="000000",
-            ),
-            Outcome(
-                slug="tastiness",
-                spec=OutcomeSpec.from_dict(toml.loads(tastiness_config)),
-                platform="firefox_desktop",
-                commit_hash="000000",
-            ),
-            Outcome(
-                slug="parameterized",
-                spec=OutcomeSpec.from_dict(toml.loads(parameterized_config)),
-                platform="firefox_desktop",
-                commit_hash="000000",
-            ),
-            Outcome(
-                slug="parameterized_distinct_by_branch_config",
-                spec=OutcomeSpec.from_dict(toml.loads(parameterized_distinct_by_branch_config)),
-                platform="firefox_desktop",
-                commit_hash="000000",
-            ),
-        ],
-        defaults=[],
-        definitions=[
-            DefinitionConfig(
-                slug="firefox_desktop",
-                spec=AnalysisSpec.from_dict(toml.loads(config_str)),
-                last_modified=dt.date.today(),
-                platform="firefox_desktop",
-            )
-        ],
-        functions=FunctionsSpec.from_dict(
-            {
-                "functions": {
-                    "agg_histogram_mean": {
-                        "definition": """SAFE_DIVIDE(
-                        SUM(CAST(JSON_EXTRACT_SCALAR({select_expr}, "$.sum") AS int64)),
-                        SUM((SELECT SUM(value)
-                        FROM UNNEST(mozfun.hist.extract({select_expr}).values)))
-                    )""",
-                    },
-                    "agg_any": {"definition": "COALESCE(LOGICAL_OR({select_expr}), FALSE)"},
-                }
-            }
-        ),
-    )
 
 
 @pytest.fixture
@@ -316,3 +135,11 @@ def local_tmp_repo(tmpdir):
     r.git.add(".")
     r.git.commit("-m", "commit")
     return tmpdir
+
+
+@pytest.fixture
+def config_collection(local_tmp_repo):
+    default_metrics = ConfigCollection.from_github_repo(local_tmp_repo, path="metrics")
+    jetstream_metrics = ConfigCollection.from_github_repo(local_tmp_repo, path="metrics/jetstream")
+    default_metrics.merge(jetstream_metrics)
+    return default_metrics

--- a/metric_config_parser/tests/data/definitions/firefox_desktop.toml
+++ b/metric_config_parser/tests/data/definitions/firefox_desktop.toml
@@ -15,6 +15,8 @@ description = """
 """
 bigger_is_better = false
 
+[metrics.unenroll.statistics.bootstrap_mean]
+
 
 [metrics.active_hours]
 friendly_name = "Active hours"
@@ -26,8 +28,38 @@ description = """
 select_expression = '{{agg_sum("active_hours_sum")}}'
 data_source = "clients_daily"
 
+[metrics.active_hours.statistics.bootstrap_mean]
+
+
+[metrics.days_of_use]
+data_source = "clients_daily"
+select_expression = "COUNT(submission_date)"
+friendly_name = "Days of use"
+description = "The number of days in the interval that each client sent a main ping."
+
+[metrics.days_of_use.statistics.bootstrap_mean]
+
+
+[metrics.view_about_logins]
+data_source = "events"
+select_expression = '''{{agg_any(
+    """
+            event_method = 'open_management'
+            AND event_category = 'pwmgr'
+        """
+)}}'''
+friendly_name = "about:logins viewers"
+description = """
+    Counts the number of clients that viewed about:logins.
+"""
+
+[metrics.view_about_logins.statistics.bootstrap_mean]
+
 
 [data_sources]
+
+[data_sources.main]
+from_expression = "SELECT 1"
 
 [data_sources.clients_daily]
 from_expression = "mozdata.telemetry.clients_daily"
@@ -44,3 +76,21 @@ from_expression = """(
 experiments_column_type="native"
 friendly_name = "Normandy Events"
 description = "Normandy Events"
+
+[data_sources.events]
+from_expression = "mozdata.telemetry.events"
+experiments_column_type = "native"
+friendly_name = "Events"
+description = "Events Ping"
+
+[segments]
+
+[segments.regular_users_v3]
+data_source = "my_cool_data_source"
+select_expression = "{{agg_any('1')}}"
+
+[segments.data_sources.my_cool_data_source]
+from_expression = '''
+    (SELECT 1 WHERE submission_date BETWEEN {{experiment.start_date_str}}
+    AND {{experiment.last_enrollment_date_str}})
+'''

--- a/metric_config_parser/tests/data/jetstream/outcomes/firefox_desktop/parameterized.toml
+++ b/metric_config_parser/tests/data/jetstream/outcomes/firefox_desktop/parameterized.toml
@@ -1,0 +1,15 @@
+friendly_name = "Outcome with parameter same across all branches"
+description = "Outcome that has a parameter that is the same across all branches"
+default_metrics = ["sample_id_count"]
+
+[metrics.sample_id_count]
+data_source = "main"
+select_expression = "COUNTIF(sample_id = {{ parameters.id }})"
+
+[metrics.sample_id_count.statistics.bootstrap_mean]
+
+[parameters.id]
+friendly_name = "Some random ID"
+description = "A random ID used to count samples"
+default = "700"
+distinct_by_branch = false

--- a/metric_config_parser/tests/data/jetstream/outcomes/firefox_desktop/parameterized_distinct_by_branch_config.toml
+++ b/metric_config_parser/tests/data/jetstream/outcomes/firefox_desktop/parameterized_distinct_by_branch_config.toml
@@ -1,0 +1,16 @@
+friendly_name = "Outcome with parameter same across all branches"
+description = "Outcome that has a parameter that is the same across all branches"
+default_metrics = ["sample_id_count"]
+
+[metrics.sample_id_count]
+data_source = "main"
+select_expression = "COUNTIF(sample_id = {{ parameters.id }})"
+
+[metrics.sample_id_count.statistics.bootstrap_mean]
+
+[parameters.id]
+friendly_name = "Some random ID"
+description = "A random ID used to count samples"
+distinct_by_branch = true
+
+default.branch_1 = 1

--- a/metric_config_parser/tests/data/jetstream/outcomes/firefox_desktop/performance.toml
+++ b/metric_config_parser/tests/data/jetstream/outcomes/firefox_desktop/performance.toml
@@ -1,0 +1,9 @@
+friendly_name = "Performance outcomes"
+description = "Outcomes related to performance"
+default_metrics = ["speed"]
+
+[metrics.speed]
+data_source = "main"
+select_expression = "1"
+
+[metrics.speed.statistics.bootstrap_mean]

--- a/metric_config_parser/tests/data/jetstream/outcomes/firefox_desktop/tastiness.toml
+++ b/metric_config_parser/tests/data/jetstream/outcomes/firefox_desktop/tastiness.toml
@@ -1,0 +1,16 @@
+friendly_name = "Tastiness outcomes"
+description = "Outcomes related to tastiness 😋"
+
+[metrics.meals_eaten]
+data_source = "meals"
+select_expression = "1"
+friendly_name = "Meals eaten"
+description = "Number of consumed meals"
+
+[metrics.meals_eaten.statistics.bootstrap_mean]
+num_samples = 10
+pre_treatments = ["remove_nulls"]
+
+[data_sources.meals]
+from_expression = "meals"
+client_id_column = "client_info.client_id"

--- a/metric_config_parser/tests/sql/test_generate_data_source.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_data_source.expected.sql
@@ -1,0 +1,8 @@
+(
+    SELECT
+        *
+    FROM
+        (SELECT 1)
+    WHERE
+        submission_date = '2023-01-01'
+    )

--- a/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
@@ -11,6 +11,7 @@ WITH clients_daily AS (
     GROUP BY    
         client_id,
         submission_date
+        
 )
 SELECT
     clients_daily.client_id,

--- a/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
@@ -1,0 +1,23 @@
+(
+WITH clients_daily AS (
+    SELECT
+        client_id AS client_id,
+        submission_date AS submission_date,
+        COALESCE(SUM(active_hours_sum), 0) AS active_hours,
+        COUNT(submission_date) AS days_of_use,
+        
+    FROM
+        mozdata.telemetry.clients_daily
+    GROUP BY    
+        client_id,
+        submission_date
+)
+SELECT
+    clients_daily.client_id,
+    clients_daily.submission_date,
+    active_hours,
+    days_of_use,
+    
+FROM
+    clients_daily
+)

--- a/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
@@ -1,0 +1,21 @@
+(
+WITH clients_daily AS (
+    SELECT
+        client_id AS client_id,
+        submission_date AS submission_date,
+        COALESCE(SUM(active_hours_sum), 0) AS active_hours,
+        
+    FROM
+        mozdata.telemetry.clients_daily
+    GROUP BY    
+        client_id,
+        submission_date
+)
+SELECT
+    clients_daily.client_id,
+    clients_daily.submission_date,
+    active_hours,
+    
+FROM
+    clients_daily
+)

--- a/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
@@ -10,6 +10,7 @@ WITH clients_daily AS (
     GROUP BY    
         client_id,
         submission_date
+        
 )
 SELECT
     clients_daily.client_id,

--- a/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
@@ -17,6 +17,7 @@ WITH clients_daily AS (
         sample_id,
         client_id,
         submission_date
+        
 ),
  normandy_events AS (
     SELECT
@@ -43,6 +44,7 @@ WITH clients_daily AS (
         sample_id,
         client_id,
         submission_date
+        
 ),
  events AS (
     SELECT
@@ -63,6 +65,7 @@ WITH clients_daily AS (
         sample_id,
         client_id,
         submission_date
+        
 )
 SELECT
     clients_daily.client_id,

--- a/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
@@ -1,0 +1,91 @@
+(
+WITH clients_daily AS (
+    SELECT
+        client_id AS client_id,
+        submission_date AS submission_date,
+        build_id AS build_id,
+        sample_id AS sample_id,
+        COALESCE(SUM(active_hours_sum), 0) AS active_hours,
+        COUNT(submission_date) AS days_of_use,
+        
+    FROM
+        mozdata.telemetry.clients_daily
+    WHERE
+        submission_date = '2023-01-01' AND normalized_channel = 'release'
+    GROUP BY    
+        build_id,
+        sample_id,
+        client_id,
+        submission_date
+),
+ normandy_events AS (
+    SELECT
+        client_id AS client_id,
+        submission_date AS submission_date,
+        build_id AS build_id,
+        sample_id AS sample_id,
+        COALESCE(LOGICAL_OR(        event_category = 'normandy'
+        AND event_method = 'unenroll'
+        AND event_string_value = '{experiment_slug}'
+     ), FALSE) AS unenroll,
+        
+    FROM
+        (
+    SELECT
+        *
+    FROM mozdata.telemetry.events
+    WHERE event_category = 'normandy'
+)
+    WHERE
+        submission_date = '2023-01-01' AND normalized_channel = 'release'
+    GROUP BY    
+        build_id,
+        sample_id,
+        client_id,
+        submission_date
+),
+ events AS (
+    SELECT
+        client_id AS client_id,
+        submission_date AS submission_date,
+        build_id AS build_id,
+        sample_id AS sample_id,
+        COALESCE(LOGICAL_OR(            event_method = 'open_management'
+            AND event_category = 'pwmgr'
+         ), FALSE) AS view_about_logins,
+        
+    FROM
+        mozdata.telemetry.events
+    WHERE
+        submission_date = '2023-01-01' AND normalized_channel = 'release'
+    GROUP BY    
+        build_id,
+        sample_id,
+        client_id,
+        submission_date
+)
+SELECT
+    clients_daily.client_id,
+    clients_daily.submission_date,
+    clients_daily.build_id AS build_id,
+    clients_daily.sample_id AS sample_id,
+    active_hours,
+    days_of_use,
+    unenroll,
+    view_about_logins,
+    
+FROM
+    clients_daily
+FULL OUTER JOIN normandy_events
+    ON
+        normandy_events.submission_date = clients_daily.submission_date AND
+        normandy_events.client_id = clients_daily.client_id 
+        AND normandy_events.build_id = clients_daily.build_id 
+        AND normandy_events.sample_id = clients_daily.sample_id 
+        FULL OUTER JOIN events
+    ON
+        events.submission_date = clients_daily.submission_date AND
+        events.client_id = clients_daily.client_id 
+        AND events.build_id = clients_daily.build_id 
+        AND events.sample_id = clients_daily.sample_id 
+        )

--- a/metric_config_parser/tests/sql/test_generate_query_with_parameters.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_parameters.expected.sql
@@ -1,0 +1,31 @@
+(
+WITH clients_daily AS (
+    SELECT
+        client_id AS client_id,
+        submission_date AS submission_date,
+        build_id AS build_id,
+        sample_id AS sample_id,
+        COALESCE(SUM(active_hours_sum), 0) AS active_hours,
+        COUNT(submission_date) AS days_of_use,
+        
+    FROM
+        mozdata.telemetry.clients_daily
+    WHERE
+        submission_date = '2023-01-01' AND normalized_channel = 'release'
+    GROUP BY    
+        build_id,
+        sample_id,
+        client_id,
+        submission_date
+)
+SELECT
+    clients_daily.client_id,
+    clients_daily.submission_date,
+    clients_daily.build_id AS build_id,
+    clients_daily.sample_id AS sample_id,
+    active_hours,
+    days_of_use,
+    
+FROM
+    clients_daily
+)

--- a/metric_config_parser/tests/sql/test_generate_query_without_client_id.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_without_client_id.expected.sql
@@ -1,31 +1,20 @@
 (
 WITH clients_daily AS (
     SELECT
-        client_id AS client_id,
-        submission_date AS submission_date,
         build_id AS build_id,
-        sample_id AS sample_id,
         COALESCE(SUM(active_hours_sum), 0) AS active_hours,
-        COUNT(submission_date) AS days_of_use,
         
     FROM
         mozdata.telemetry.clients_daily
     WHERE
         submission_date = '2023-01-01' AND normalized_channel = 'release'
     GROUP BY    
-        build_id,
-        sample_id,
-        client_id,
-        submission_date
+        build_id
         
 )
 SELECT
-    clients_daily.client_id,
-    clients_daily.submission_date,
     clients_daily.build_id AS build_id,
-    clients_daily.sample_id AS sample_id,
     active_hours,
-    days_of_use,
     
 FROM
     clients_daily

--- a/metric_config_parser/tests/test_sql.py
+++ b/metric_config_parser/tests/test_sql.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent
+TEST_DATA = ROOT / "sql"
+
+
+def test_generate_query_single_metric(config_collection):
+    assert (
+        config_collection.get_metrics_sql(metrics=["active_hours"], platform="firefox_desktop")
+        == (TEST_DATA / "test_generate_query_single_metric.expected.sql").read_text()
+    )
+
+
+def test_generate_query_multiple_metrics(config_collection):
+    assert (
+        config_collection.get_metrics_sql(
+            metrics=["active_hours", "days_of_use"], platform="firefox_desktop"
+        )
+        == (TEST_DATA / "test_generate_query_multiple_metrics.expected.sql").read_text()
+    )
+
+
+def test_generate_query_with_parameters(config_collection):
+    assert (
+        config_collection.get_metrics_sql(
+            metrics=["active_hours", "days_of_use"],
+            platform="firefox_desktop",
+            group_by=["build_id", "sample_id"],
+            where="submission_date = '2023-01-01' AND normalized_channel = 'release'",
+        )
+        == (TEST_DATA / "test_generate_query_with_parameters.expected.sql").read_text()
+    )
+
+    assert (
+        config_collection.get_metrics_sql(
+            metrics=["active_hours", "days_of_use"],
+            platform="firefox_desktop",
+            group_by={"build_id": "build_id", "sample_id": "sample_id"},
+            where="submission_date = '2023-01-01' AND normalized_channel = 'release'",
+        )
+        == (TEST_DATA / "test_generate_query_with_parameters.expected.sql").read_text()
+    )
+
+
+def test_generate_query_with_multiple_metrics_different_data_sources(config_collection):
+    assert (
+        config_collection.get_metrics_sql(
+            metrics=["active_hours", "days_of_use", "unenroll", "view_about_logins"],
+            platform="firefox_desktop",
+            group_by=["build_id", "sample_id"],
+            where="submission_date = '2023-01-01' AND normalized_channel = 'release'",
+        )
+        == (
+            TEST_DATA
+            / "test_generate_query_with_multiple_metrics_different_data_sources.expected.sql"
+        ).read_text()
+    )
+
+
+def test_no_metric_definition_found(config_collection):
+    with pytest.raises(ValueError):
+        config_collection.get_metrics_sql(metrics=["doesnt-exist"], platform="firefox_desktop")

--- a/metric_config_parser/tests/test_sql.py
+++ b/metric_config_parser/tests/test_sql.py
@@ -59,6 +59,20 @@ def test_generate_query_with_multiple_metrics_different_data_sources(config_coll
     )
 
 
+def test_generate_query_without_client_id_submission_date(config_collection):
+    assert (
+        config_collection.get_metrics_sql(
+            metrics=["active_hours"],
+            platform="firefox_desktop",
+            group_by=["build_id"],
+            where="submission_date = '2023-01-01' AND normalized_channel = 'release'",
+            group_by_client_id=False,
+            group_by_submission_date=False,
+        )
+        == (TEST_DATA / "test_generate_query_without_client_id.expected.sql").read_text()
+    )
+
+
 def test_no_metric_definition_found(config_collection):
     with pytest.raises(ValueError):
         config_collection.get_metrics_sql(metrics=["doesnt-exist"], platform="firefox_desktop")

--- a/metric_config_parser/tests/test_sql.py
+++ b/metric_config_parser/tests/test_sql.py
@@ -62,3 +62,19 @@ def test_generate_query_with_multiple_metrics_different_data_sources(config_coll
 def test_no_metric_definition_found(config_collection):
     with pytest.raises(ValueError):
         config_collection.get_metrics_sql(metrics=["doesnt-exist"], platform="firefox_desktop")
+
+
+def test_data_source(config_collection):
+    assert (
+        config_collection.get_data_source_sql(
+            data_source="main", platform="firefox_desktop", where="submission_date = '2023-01-01'"
+        )
+        == (TEST_DATA / "test_generate_data_source.expected.sql").read_text()
+    )
+
+
+def test_data_source_not_found(config_collection):
+    with pytest.raises(ValueError):
+        config_collection.get_data_source_sql(
+            data_source="non-existing", platform="firefox_desktop"
+        )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     ],
     package_data={
         "metric_config_parser.tests": ["data/*"],
+        "metric_config_parser": ["templates/*"],
     },
     install_requires=[
         "attrs",
@@ -63,5 +64,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2023.3.1",
+    version="2023.4.1",
 )


### PR DESCRIPTION
Used for https://github.com/mozilla/bigquery-etl/pull/3696

This adds a `get_metrics_sql` method to `ConfigCollection` which will return a SQL query for the specified metrics and parameters. 