### PR TITLE
remove default False for is_enrollment_paused

### DIFF
--- a/metric_config_parser/experiment.py
+++ b/metric_config_parser/experiment.py
@@ -68,13 +68,13 @@ class Experiment:
     reference_branch: Optional[str]
     is_high_population: bool
     app_name: str
+    is_enrollment_paused: Optional[bool]
     app_id: Optional[str] = None
     outcomes: List[str] = attr.Factory(list)
     enrollment_end_date: Optional[dt.datetime] = None
     boolean_pref: Optional[str] = None
     channel: Optional[Channel] = None
     is_rollout: bool = False
-    is_enrollment_paused: bool = False
 
 
 @attr.s(auto_attribs=True)

--- a/metric_config_parser/experiment.py
+++ b/metric_config_parser/experiment.py
@@ -121,7 +121,7 @@ class ExperimentConfiguration:
         return self.experiment.enrollment_end_date
 
     @property
-    def is_enrollment_paused(self) -> bool:
+    def is_enrollment_paused(self) -> Optional[bool]:
         return self.experiment.is_enrollment_paused
 
     @property

--- a/metric_config_parser/experiment.py
+++ b/metric_config_parser/experiment.py
@@ -68,7 +68,7 @@ class Experiment:
     reference_branch: Optional[str]
     is_high_population: bool
     app_name: str
-    is_enrollment_paused: Optional[bool]
+    is_enrollment_paused: Optional[bool] = None
     app_id: Optional[str] = None
     outcomes: List[str] = attr.Factory(list)
     enrollment_end_date: Optional[dt.datetime] = None

--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2023.4.2",
+    version="2023.4.3",
 )


### PR DESCRIPTION
This changes the parameter to Optional and sets the default to `None`. I think that defaulting to `False` for `is_enrollment_paused` is making too big an assumption here. If we cannot get the value of this flag for whatever reason, we should just use the current default behavior of checking dates.