### PR TITLE
as_of handle invalid configs

### DIFF
--- a/metric_config_parser/config.py
+++ b/metric_config_parser/config.py
@@ -11,6 +11,7 @@ import jinja2
 import toml
 from git import Repo
 from git.exc import InvalidGitRepositoryError
+from git.objects.commit import Commit
 from jinja2 import StrictUndefined
 from pytz import UTC
 
@@ -498,7 +499,7 @@ class ConfigCollection:
 
                 # keep track of more recent commits to go back to in case invalid configs
                 # got checked into main that cannot be parsed
-                newer_commits = []
+                newer_commits: List[Commit] = []
 
                 # start iterating through all commits starting at HEAD
                 for commit in tmp_repo.iter_commits("HEAD"):
@@ -507,7 +508,7 @@ class ConfigCollection:
                         rev = commit.hexsha
                         break
 
-                    newer_commits.append(commit.hexsha)
+                    newer_commits.insert(0, commit)
 
                 if commit:
                     # if there is no commit that is older than the reference timestamp,
@@ -523,14 +524,11 @@ class ConfigCollection:
                         tmp_repo, repo.path, self.is_private, repo.main_branch, is_tmp_repo=True
                     )
                 except Exception as e:
-                    print(
-                        f"Error parsing config files as of {timestamp}: {e}. Trying newer version instead."
-                    )
                     could_load_configs = False
 
                     # iterate through newer commits to find one that can be parsed
-                    for sha in newer_commits:
-                        tmp_repo.git.checkout(sha)
+                    for newer_commit in newer_commits:
+                        tmp_repo.git.checkout(newer_commit.hexsha)
 
                         try:
                             configs = self.from_local_repo(
@@ -541,6 +539,10 @@ class ConfigCollection:
                                 is_tmp_repo=True,
                             )
                             could_load_configs = True
+                            print(
+                                f"Error parsing config files as of {timestamp}: {e}. "
+                                + f"Using newer version instead of commit {newer_commit.hexsha}"
+                            )
                             break
                         except Exception:
                             # continue searching

--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2023.6.1",
+    version="2023.6.2",
 )


### PR DESCRIPTION
Have `as_of` go forward in the commit history until it finds valid configs that it can load