### PR TITLE
Remove confusing print statement

### DIFF
--- a/metric_config_parser/config.py
+++ b/metric_config_parser/config.py
@@ -542,10 +542,6 @@ class ConfigCollection:
                                 is_tmp_repo=True,
                             )
                             could_load_configs = True
-                            print(
-                                f"Error parsing config files as of {timestamp}: {e}. "
-                                + f"Using newer version instead of commit {newer_commit.hexsha}"
-                            )
                             break
                         except Exception:
                             # continue searching

--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2023.6.3",
+    version="2023.6.4",
 )


### PR DESCRIPTION
The jetstream Airflow task is logging this statement. We already had some people on Airflow triage that got confused by this, so it's better to just remove it