### PR TITLE
fix #298: add sample_size support to experiment config

### DIFF
--- a/metric_config_parser/experiment.py
+++ b/metric_config_parser/experiment.py
@@ -95,6 +95,8 @@ class ExperimentConfiguration:
     experiment: "Experiment"
     segments: List[Segment]
     exposure_signal: Optional[ExposureSignal] = None
+    # int <= 100 represents the percentage of clients for downsampling enrollments
+    sample_size: Optional[int] = None
 
     def __attrs_post_init__(self):
         # Catch any exceptions at instantiation
@@ -253,6 +255,7 @@ class ExperimentSpec:
     exposure_signal: Optional[ExposureSignalDefinition] = None
     is_private: bool = False
     dataset_id: Optional[str] = attr.ib(default=None, validator=_validate_dataset_id)
+    sample_size: Optional[int] = None
 
     def resolve(
         self, spec: "AnalysisSpec", experiment: "Experiment", configs: "ConfigCollection"
@@ -263,6 +266,8 @@ class ExperimentSpec:
         experiment_config.segments = [
             ref.resolve(spec, experiment_config, configs) for ref in self.segments
         ]
+
+        experiment_config.sample_size = self.sample_size
 
         if self.exposure_signal:
             experiment_config.exposure_signal = self.exposure_signal.resolve(

--- a/metric_config_parser/tests/test_experiment.py
+++ b/metric_config_parser/tests/test_experiment.py
@@ -267,6 +267,28 @@ class TestExperimentConf:
         cfg = spec.resolve(experiments[7], config_collection)
         assert cfg.experiment.dataset_id == "test"
 
+    def test_sample_size_defined_experiment(self, experiments, config_collection):
+        conf = dedent(
+            """
+            [experiment]
+            sample_size = 8
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(conf))
+        cfg = spec.resolve(experiments[7], config_collection)
+        assert cfg.experiment.sample_size == 8
+
+    def test_sample_size_none_experiment(self, experiments, config_collection):
+        conf = dedent(
+            """
+            [experiment]
+            enrollment_period = 7
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(conf))
+        cfg = spec.resolve(experiments[7], config_collection)
+        assert cfg.experiment.sample_size is None
+
 
 class TestDefaultConfiguration:
     def test_descriptions_defined(self, experiments, config_collection):

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2023.9.3",
+    version="2023.9.4",
 )


### PR DESCRIPTION
Adds a `sample_size` optional field to the `experiment` config in metric-hub, which defines a downsampling percentage for enrollments.

cc @danielkberry 