### PR TITLE
fix merging of analysis period metrics for experiments with outcomes

### DIFF
--- a/metric_config_parser/metric.py
+++ b/metric_config_parser/metric.py
@@ -362,10 +362,10 @@ class MetricsSpec:
 
         The `other` MetricsSpec overwrites existing metrics.
         """
-        self.daily += other.daily
-        self.weekly += other.weekly
-        self.days28 += other.days28
-        self.overall += other.overall
+        self.daily = other.daily + self.daily
+        self.weekly = other.weekly + self.weekly
+        self.days28 = other.days28 + self.days28
+        self.overall = other.overall + self.overall
 
         seen = []
         for key, _ in self.definitions.items():

--- a/metric_config_parser/tests/integration/test_config_integration.py
+++ b/metric_config_parser/tests/integration/test_config_integration.py
@@ -40,8 +40,7 @@ class TestConfigIntegration:
         experiment_config = spec.resolve(experiment, config_collection)
 
         overall_metric_names = [
-            summary.metric.name
-            for summary in experiment_config.metrics[AnalysisPeriod.OVERALL]
+            summary.metric.name for summary in experiment_config.metrics[AnalysisPeriod.OVERALL]
         ]
         assert "retained" not in overall_metric_names
 

--- a/metric_config_parser/tests/integration/test_config_integration.py
+++ b/metric_config_parser/tests/integration/test_config_integration.py
@@ -3,8 +3,9 @@ from pathlib import Path
 
 from pytz import UTC
 
+from metric_config_parser.analysis import AnalysisSpec
 from metric_config_parser.config import ConfigCollection
-from metric_config_parser.experiment import AnalysisSpec, Channel, Experiment
+from metric_config_parser.experiment import Channel, Experiment
 from metric_config_parser.metric import AnalysisPeriod
 
 

--- a/metric_config_parser/tests/integration/test_config_integration.py
+++ b/metric_config_parser/tests/integration/test_config_integration.py
@@ -4,9 +4,46 @@ from pathlib import Path
 from pytz import UTC
 
 from metric_config_parser.config import ConfigCollection
+from metric_config_parser.experiment import AnalysisSpec, Channel, Experiment
+from metric_config_parser.metric import AnalysisPeriod
 
 
 class TestConfigIntegration:
+    def test_overall_retention_regression(self):
+        config_collection = ConfigCollection.from_github_repos(
+            [
+                "https://github.com/mozilla/metric-hub",
+                "https://github.com/mozilla/metric-hub/tree/main/jetstream",
+            ]
+        )
+        experiment_slug = "ios-onboarding-search-widget"
+        config_collection.as_of(datetime.fromisoformat("2023-11-16T21:44:49+00:00"))
+        experiment = Experiment(
+            experimenter_slug=None,
+            normandy_slug=experiment_slug,
+            type="v6",
+            status="Complete",
+            branches=["control", "treatment-a", "treatment-b"],
+            reference_branch="control",
+            is_high_population=False,
+            start_date=datetime(2023, 9, 12),
+            proposed_enrollment=14,
+            enrollment_end_date=datetime(2023, 9, 26),
+            end_date=datetime(2023, 10, 24),
+            app_name="firefox_ios",
+            channel=Channel.RELEASE,
+            is_enrollment_paused=True,
+            outcomes=["onboarding"],
+        )
+        spec = AnalysisSpec.default_for_experiment(experiment, config_collection)
+        experiment_config = spec.resolve(experiment, config_collection)
+
+        overall_metric_names = [
+            summary.metric.name
+            for summary in experiment_config.metrics[AnalysisPeriod.OVERALL]
+        ]
+        assert "retained" not in overall_metric_names
+
     def test_configs_from_repo(self):
         config_collection = ConfigCollection.from_github_repos(
             ["https://github.com/mozilla/metric-hub"]

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2023.10.2",
+    version="2023.11.1",
 )


### PR DESCRIPTION
#335 inverted the precedence of outcomes when merging, but this led to a bug with the merging of metrics for each analysis period where all periods would get all metrics somehow. This changes the method for merging the metrics lists and adds a regression test to guard against the broken behavior.

This should fix the issue leading to this error in Experimenter: https://github.com/mozilla/experimenter/issues/9700