### PR TITLE
rename week_preenrollment and add period conflict test

### DIFF
--- a/metric_config_parser/metric.py
+++ b/metric_config_parser/metric.py
@@ -29,7 +29,7 @@ class AnalysisPeriod(Enum):
     WEEK = "week"
     DAYS_28 = "days28"
     OVERALL = "overall"
-    WEEK_PREENROLLMENT = "week_preenrollment"
+    WEEK_PREENROLLMENT = "weekly_preenrollment"
     DAYS_28_PREENROLLMENT = "days28_preenrollment"
 
     @property
@@ -39,7 +39,7 @@ class AnalysisPeriod(Enum):
             "week": "weekly",
             "days28": "28_day",
             "overall": "overall",
-            "week_preenrollment": "week_preenrollment",
+            "weekly_preenrollment": "weekly_preenrollment",
             "days28_preenrollment": "days28_preenrollment",
         }
         return d[self.value]
@@ -51,7 +51,7 @@ class AnalysisPeriod(Enum):
             "week": "weekly",
             "days28": "days28",
             "overall": "overall",
-            "week_preenrollment": "week_preenrollment",
+            "weekly_preenrollment": "weekly_preenrollment",
             "days28_preenrollment": "days28_preenrollment",
         }
         return d[self.value]
@@ -340,7 +340,7 @@ class MetricsSpec:
     weekly: List[MetricReference] = attr.Factory(list)
     days28: List[MetricReference] = attr.Factory(list)
     overall: List[MetricReference] = attr.Factory(list)
-    week_preenrollment: List[MetricReference] = attr.Factory(list)
+    weekly_preenrollment: List[MetricReference] = attr.Factory(list)
     days28_preenrollment: List[MetricReference] = attr.Factory(list)
     definitions: Dict[str, MetricDefinition] = attr.Factory(dict)
 
@@ -404,7 +404,7 @@ class MetricsSpec:
         self.weekly = other.weekly + self.weekly
         self.days28 = other.days28 + self.days28
         self.overall = other.overall + self.overall
-        self.week_preenrollment = other.week_preenrollment + self.week_preenrollment
+        self.weekly_preenrollment = other.weekly_preenrollment + self.weekly_preenrollment
         self.days28_preenrollment = other.days28_preenrollment + self.days28_preenrollment
 
         seen = []

--- a/metric_config_parser/metric.py
+++ b/metric_config_parser/metric.py
@@ -29,8 +29,8 @@ class AnalysisPeriod(Enum):
     WEEK = "week"
     DAYS_28 = "days28"
     OVERALL = "overall"
-    WEEK_PREENROLLMENT = "weekly_preenrollment"
-    DAYS_28_PREENROLLMENT = "days28_preenrollment"
+    PREENROLLMENT_WEEK = "preenrollment_week"
+    PREENROLLMENT_DAYS_28 = "preenrollment_days28"
 
     @property
     def mozanalysis_label(self) -> str:
@@ -39,8 +39,8 @@ class AnalysisPeriod(Enum):
             "week": "weekly",
             "days28": "28_day",
             "overall": "overall",
-            "weekly_preenrollment": "weekly_preenrollment",
-            "days28_preenrollment": "days28_preenrollment",
+            "preenrollment_week": "preenrollment_weekly",
+            "preenrollment_days28": "preenrollment_days28",
         }
         return d[self.value]
 
@@ -51,8 +51,8 @@ class AnalysisPeriod(Enum):
             "week": "weekly",
             "days28": "days28",
             "overall": "overall",
-            "weekly_preenrollment": "weekly_preenrollment",
-            "days28_preenrollment": "days28_preenrollment",
+            "preenrollment_week": "preenrollment_weekly",
+            "preenrollment_days28": "preenrollment_days28",
         }
         return d[self.value]
 
@@ -340,8 +340,8 @@ class MetricsSpec:
     weekly: List[MetricReference] = attr.Factory(list)
     days28: List[MetricReference] = attr.Factory(list)
     overall: List[MetricReference] = attr.Factory(list)
-    weekly_preenrollment: List[MetricReference] = attr.Factory(list)
-    days28_preenrollment: List[MetricReference] = attr.Factory(list)
+    preenrollment_weekly: List[MetricReference] = attr.Factory(list)
+    preenrollment_days28: List[MetricReference] = attr.Factory(list)
     definitions: Dict[str, MetricDefinition] = attr.Factory(dict)
 
     @classmethod
@@ -404,8 +404,8 @@ class MetricsSpec:
         self.weekly = other.weekly + self.weekly
         self.days28 = other.days28 + self.days28
         self.overall = other.overall + self.overall
-        self.weekly_preenrollment = other.weekly_preenrollment + self.weekly_preenrollment
-        self.days28_preenrollment = other.days28_preenrollment + self.days28_preenrollment
+        self.preenrollment_weekly = other.preenrollment_weekly + self.preenrollment_weekly
+        self.preenrollment_days28 = other.preenrollment_days28 + self.preenrollment_days28
 
         seen = []
         for key, _ in self.definitions.items():

--- a/metric_config_parser/tests/test_experiment.py
+++ b/metric_config_parser/tests/test_experiment.py
@@ -177,12 +177,12 @@ class TestExperimentSpec:
         assert len(overall_pre_treatments) == 1
         assert overall_pre_treatments[0].name == "remove_nulls"
 
-    def test_preenrollmennt(self, experiments, config_collection):
+    def test_preenrollment(self, experiments, config_collection):
         config_str = dedent(
             """
             [metrics]
-            days28_preenrollment = ["spam"]
-            weekly_preenrollment = ["spam"]
+            preenrollment_days28 = ["spam"]
+            preenrollment_weekly = ["spam"]
 
             [metrics.spam]
             data_source = "main"
@@ -195,14 +195,14 @@ class TestExperimentSpec:
         spec = AnalysisSpec.from_dict(toml.loads(config_str))
         cfg = spec.resolve(experiments[0], config_collection)
         week_metrics = [
-            m for m in cfg.metrics[AnalysisPeriod.WEEK_PREENROLLMENT] if m.metric.name == "spam"
+            m for m in cfg.metrics[AnalysisPeriod.PREENROLLMENT_WEEK] if m.metric.name == "spam"
         ]
 
         assert len(week_metrics) == 1
         assert week_metrics[0].metric.name == "spam"
 
         days28_metrics = [
-            m for m in cfg.metrics[AnalysisPeriod.DAYS_28_PREENROLLMENT] if m.metric.name == "spam"
+            m for m in cfg.metrics[AnalysisPeriod.PREENROLLMENT_DAYS_28] if m.metric.name == "spam"
         ]
 
         assert len(days28_metrics) == 1

--- a/metric_config_parser/tests/test_experiment.py
+++ b/metric_config_parser/tests/test_experiment.py
@@ -182,7 +182,7 @@ class TestExperimentSpec:
             """
             [metrics]
             days28_preenrollment = ["spam"]
-            week_preenrollment = ["spam"]
+            weekly_preenrollment = ["spam"]
 
             [metrics.spam]
             data_source = "main"

--- a/metric_config_parser/tests/test_metric.py
+++ b/metric_config_parser/tests/test_metric.py
@@ -1,6 +1,6 @@
 import pytest
 
-from metric_config_parser.metric import MetricDefinition
+from metric_config_parser.metric import AnalysisPeriod, MetricDefinition
 from metric_config_parser.parameter import ParameterDefinition
 
 
@@ -75,3 +75,8 @@ class TestMetricDefinition:
             param_definition, select_template, config_collection
         )
         assert expected == actual
+
+    def test_analysis_periods_conflicts(self):
+        for test_period in AnalysisPeriod:
+            for period in [p for p in AnalysisPeriod if p != test_period]:
+                assert not period.value.startswith(test_period.value)

--- a/metric_config_parser/tests/test_metric.py
+++ b/metric_config_parser/tests/test_metric.py
@@ -79,4 +79,4 @@ class TestMetricDefinition:
     def test_analysis_periods_conflicts(self):
         for test_period in AnalysisPeriod:
             for period in [p for p in AnalysisPeriod if p != test_period]:
-                assert not period.value.startswith(test_period.value)
+                assert not period.value.startswith(f"{test_period.value}_")

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2024.3.2",
+    version="2024.4.1",
 )


### PR DESCRIPTION
Rename the `week_preenrollment` analysis window to avoid wildcard table query error when building views in Jetstream.

Also adds a test to ensure that we avoid this issue going forward.