### PR TITLE
Support wildcard in slugs

### DIFF
--- a/metric_config_parser/data_source.py
+++ b/metric_config_parser/data_source.py
@@ -2,6 +2,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import attr
+import fnmatch
+import re
 
 from metric_config_parser.errors import DefinitionNotFound
 
@@ -11,7 +13,7 @@ if TYPE_CHECKING:
     from .definition import DefinitionSpecSub
     from .project import ProjectConfiguration
 
-from .util import converter
+from .util import converter, is_valid_slug
 
 
 class DataSourceJoinRelationship(Enum):
@@ -167,6 +169,12 @@ class DataSourceDefinition:
         conf: Union["ExperimentConfiguration", "ProjectConfiguration"],
         configs: "ConfigCollection",
     ) -> DataSource:
+        if not is_valid_slug(self.name):
+            raise ValueError(
+                f"Invalid identifier found in name {self.name}. "
+                + "Name must at least consist of one character, number or underscore. "
+                + "Wildcard characters are only allowed if matching slug is defined."
+            ) 
         params: Dict[str, Any] = {"name": self.name, "from_expression": self.from_expression}
         # Allow mozanalysis to infer defaults for these values:
         for k in (
@@ -211,7 +219,8 @@ class DataSourceDefinition:
     def merge(self, other: "DataSourceDefinition"):
         """Merge with another data source definition."""
         for key in attr.fields_dict(type(self)):
-            setattr(self, key, getattr(other, key) or getattr(self, key))
+            if key != "name":
+                setattr(self, key, getattr(other, key) or getattr(self, key))
 
 
 @attr.s(auto_attribs=True)
@@ -238,13 +247,16 @@ class DataSourcesSpec:
         Merge another datasource spec into the current one.
         The `other` DataSourcesSpec overwrites existing keys.
         """
-        seen = []
+        seen = set()
         for key, _ in self.definitions.items():
-            if key in other.definitions:
-                self.definitions[key].merge(other.definitions[key])
-            seen.append(key)
+            for other_key in other.definitions:
+                other_key_regex = re.compile(fnmatch.translate(other_key))
+                if other_key_regex.fullmatch(key):
+                    self.definitions[key].merge(other.definitions[other_key])
+                    seen.add(other_key)
+            seen.add(key)
         for key, definition in other.definitions.items():
-            if key not in seen:
+            if key not in seen and is_valid_slug(key):
                 self.definitions[key] = definition
 
 

--- a/metric_config_parser/data_source.py
+++ b/metric_config_parser/data_source.py
@@ -1,9 +1,9 @@
 from enum import Enum
+import fnmatch
+import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import attr
-import fnmatch
-import re
 
 from metric_config_parser.errors import DefinitionNotFound
 
@@ -250,6 +250,7 @@ class DataSourcesSpec:
         seen = set()
         for key, _ in self.definitions.items():
             for other_key in other.definitions:
+                # support wildcard characters in `other`
                 other_key_regex = re.compile(fnmatch.translate(other_key))
                 if other_key_regex.fullmatch(key):
                     self.definitions[key].merge(other.definitions[other_key])

--- a/metric_config_parser/data_source.py
+++ b/metric_config_parser/data_source.py
@@ -1,6 +1,6 @@
-from enum import Enum
 import fnmatch
 import re
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import attr
@@ -170,11 +170,15 @@ class DataSourceDefinition:
         configs: "ConfigCollection",
     ) -> DataSource:
         if not is_valid_slug(self.name):
+            # a data source name cannot include a wildcard * because if
+            # it does at this point in the code,
+            # that means it isn't defined anywhere and there's some dangling wildcard
             raise ValueError(
                 f"Invalid identifier found in name {self.name}. "
                 + "Name must at least consist of one character, number or underscore. "
                 + "Wildcard characters are only allowed if matching slug is defined."
-            ) 
+            )
+
         params: Dict[str, Any] = {"name": self.name, "from_expression": self.from_expression}
         # Allow mozanalysis to infer defaults for these values:
         for k in (

--- a/metric_config_parser/tests/test_config.py
+++ b/metric_config_parser/tests/test_config.py
@@ -609,6 +609,7 @@ class TestConfigIntegration:
             )
 
     def test_invalid_wildcard_in_data_source(self):
+        # needs to be [data_sources.'baseline_*']
         config_str = dedent(
             """
             [data_sources.baseline_*]

--- a/metric_config_parser/tests/test_config.py
+++ b/metric_config_parser/tests/test_config.py
@@ -630,6 +630,7 @@ class TestConfigIntegration:
             """
             [metrics.test_metric]
             select_expression = 1
+            category = "test"
 
             [data_sources.baseline]
             from_expression = "mozdata.search.baseline"
@@ -654,8 +655,12 @@ class TestConfigIntegration:
 
             [metrics.'test_*']
             data_source = "baseline"
+            category = "test_overwrite_first"
 
             [metrics.'test_*'.statistics.bootstrap_mean]
+
+            [metrics.'test_me*']
+            category = "test_overwrite_second"
             """
         )
         definition = DefinitionConfig(
@@ -701,6 +706,10 @@ class TestConfigIntegration:
             in config_collection_1.get_metric_definition(
                 "test_metric", "firefox_desktop"
             ).statistics
+        )
+        assert (
+            config_collection_1.get_metric_definition("test_metric", "firefox_desktop").category
+            == "test_overwrite_second"
         )
 
     def test_merge_with_wildcards_invalid(self):
@@ -752,4 +761,3 @@ class TestConfigIntegration:
         assert (
             config_collection_1.get_data_source_definition("invalid_*", "firefox_desktop") is None
         )
-

--- a/metric_config_parser/util.py
+++ b/metric_config_parser/util.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 import tempfile
 from contextlib import contextmanager
@@ -7,7 +8,6 @@ from typing import Optional
 
 import cattr
 import pytz
-import re
 
 converter = cattr.Converter()
 

--- a/metric_config_parser/util.py
+++ b/metric_config_parser/util.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import cattr
 import pytz
+import re
 
 converter = cattr.Converter()
 
@@ -25,3 +26,8 @@ def parse_date(yyyy_mm_dd: Optional[str]) -> Optional[datetime]:
     if not yyyy_mm_dd:
         return None
     return datetime.strptime(yyyy_mm_dd, "%Y-%m-%d").replace(tzinfo=pytz.utc)
+
+
+def is_valid_slug(slug: str) -> bool:
+    """Returns whether a slug name is valid."""
+    return bool(re.match(r"^[a-zA-Z0-9_]+$", slug))

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2024.4.1",
+    version="2024.5.1",
 )


### PR DESCRIPTION
This adds support for using wildcard characters in data_source and metric slugs to be used when merging two config collections. For example, this allows to apply statistics to multiple metrics in a single expression. This makes defining metrics to be exposed in Looker a bit easier:

In `definitions/`
```toml
[metrics.bookmarks_added]
data_source = "baseline"
select_expression = "COUNT(bookmarks_add)"

[metrics.bookmarks_deleted]
data_source = "baseline"
select_expression = "COUNT(bookmark_delete)"

[data_sources.baseline]
from_expression = "mozdata.search.baseline"
experiments_column_type = "simple"

```

In `looker/`
```toml
[metrics.'bookmarks_*'.statistics.sum]
```

For multiple wildcard expressions targeting the same metric definition, whatever is defined last in the config takes precedence:

```toml
[metrics.'*']
category = "bla"

[metrics.'test_*']
category = "test"  # takes precedence over category 'bla'
```
