### PR TITLE
Join support

### DIFF
--- a/metric_config_parser/analysis.py
+++ b/metric_config_parser/analysis.py
@@ -162,9 +162,11 @@ class AnalysisSpec:
                 "friendly_name": getattr(param_1, "friendly_name", None)
                 or getattr(param_2, "friendly_name"),
                 "description": getattr(param_1, "description", None) or param_2.description,
-                "value": {branch: branch_value for branch, branch_value in final_value.items()}
-                if isinstance(final_value, dict)
-                else final_value,
+                "value": (
+                    {branch: branch_value for branch, branch_value in final_value.items()}
+                    if isinstance(final_value, dict)
+                    else final_value
+                ),
                 "default": getattr(param_1, "default", None)
                 or default_value
                 or (dict() if isinstance(final_value, dict) else None),

--- a/metric_config_parser/config.py
+++ b/metric_config_parser/config.py
@@ -679,10 +679,18 @@ class ConfigCollection:
         )
 
     def get_data_source_sql(
-        self, data_source: str, platform: str, where: Optional[str] = None
+        self,
+        data_source: str,
+        platform: str,
+        where: Optional[str] = None,
+        select_fields: bool = True,
     ) -> str:
         return generate_data_source_sql(
-            self, data_source=data_source, platform=platform, where=where
+            self,
+            data_source=data_source,
+            platform=platform,
+            where=where,
+            select_fields=select_fields,
         )
 
     def get_env(self) -> jinja2.Environment:

--- a/metric_config_parser/data_source.py
+++ b/metric_config_parser/data_source.py
@@ -1,7 +1,7 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union, List
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import attr
-from enum import Enum
 
 from metric_config_parser.errors import DefinitionNotFound
 
@@ -18,6 +18,7 @@ class DataSourceJoinRelationship(Enum):
     ONE_TO_ONE = "one_to_one"
     MANY_TO_ONE = "many_to_one"
     ONE_TO_MANY = "one_to_many"
+    MANY_TO_MANY = "many_to_many"
 
     @staticmethod
     def from_str(label):

--- a/metric_config_parser/data_source.py
+++ b/metric_config_parser/data_source.py
@@ -29,6 +29,8 @@ class DataSourceJoinRelationship(Enum):
                 return DataSourceJoinRelationship.MANY_TO_ONE
             case "one_to_many":
                 return DataSourceJoinRelationship.ONE_TO_MANY
+            case "many_to_many":
+                return DataSourceJoinRelationship.MANY_TO_MANY
             case _:
                 raise NotImplementedError
 

--- a/metric_config_parser/data_source.py
+++ b/metric_config_parser/data_source.py
@@ -157,6 +157,7 @@ class DataSourceDefinition:
     friendly_name: Optional[str] = None
     description: Optional[str] = None
     joins: Optional[Dict[str, Dict[str, Any]]] = None
+    columns_as_dimensions: Optional[bool] = None
 
     def resolve(
         self,
@@ -174,6 +175,7 @@ class DataSourceDefinition:
             "build_id_column",
             "friendly_name",
             "description",
+            "columns_as_dimensions",
         ):
             v = getattr(self, k)
             if v:

--- a/metric_config_parser/metric.py
+++ b/metric_config_parser/metric.py
@@ -224,9 +224,9 @@ class MetricDefinition:
                     name=self.name,
                     data_source=None,
                     select_expression=None,
-                    friendly_name=dedent(self.friendly_name)
-                    if self.friendly_name
-                    else self.friendly_name,
+                    friendly_name=(
+                        dedent(self.friendly_name) if self.friendly_name else self.friendly_name
+                    ),
                     description=dedent(self.description) if self.description else self.description,
                     bigger_is_better=self.bigger_is_better,
                     analysis_bases=self.analysis_bases
@@ -256,9 +256,9 @@ class MetricDefinition:
                 name=self.name,
                 data_source=self.data_source.resolve(spec, conf, configs),
                 select_expression=select_expression,
-                friendly_name=dedent(self.friendly_name)
-                if self.friendly_name
-                else self.friendly_name,
+                friendly_name=(
+                    dedent(self.friendly_name) if self.friendly_name else self.friendly_name
+                ),
                 description=dedent(self.description) if self.description else self.description,
                 bigger_is_better=self.bigger_is_better,
                 analysis_bases=self.analysis_bases

--- a/metric_config_parser/population.py
+++ b/metric_config_parser/population.py
@@ -54,17 +54,21 @@ class PopulationSpec:
             boolean_pref=self.boolean_pref
             or (conf.population.boolean_pref if conf and not conf.is_rollout else None),
             channel=self.channel or (conf.population.channel if conf else None),
-            branches=self.branches
-            if self.branches is not None
-            else (
-                [branch for branch in conf.population.branches]
-                if conf and self.boolean_pref is None and not conf.is_rollout
-                else []
+            branches=(
+                self.branches
+                if self.branches is not None
+                else (
+                    [branch for branch in conf.population.branches]
+                    if conf and self.boolean_pref is None and not conf.is_rollout
+                    else []
+                )
             ),
             monitor_entire_population=self.monitor_entire_population,
-            group_by_dimension=self.group_by_dimension.resolve(spec, conf, configs)
-            if self.group_by_dimension
-            else None,
+            group_by_dimension=(
+                self.group_by_dimension.resolve(spec, conf, configs)
+                if self.group_by_dimension
+                else None
+            ),
         )
 
     def merge(self, other: "PopulationSpec") -> None:

--- a/metric_config_parser/sql.py
+++ b/metric_config_parser/sql.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 FILE_PATH = Path(os.path.dirname(__file__))
 METRICS_QUERY = FILE_PATH / "templates" / "metrics_query.sql"
 DATA_SOURCE_QUERY = FILE_PATH / "templates" / "data_source_query.sql"
+DATA_SOURCE_MACROS = FILE_PATH / "templates" / "data_source_macros.j2"
 
 
 def generate_metrics_sql(
@@ -70,7 +71,12 @@ def generate_metrics_sql(
     if isinstance(group_by, list):
         group_by = {g: g for g in group_by}
 
+    macros_template = DATA_SOURCE_MACROS.read_text()
     template = METRICS_QUERY.read_text()
+
+    # using `from_string()` in Jinja doens't support include statements, so
+    # substituting them here manually
+    template = template.replace("{% include 'data_source_macros.j2' %}", macros_template)
     return (
         config_collection.get_env()
         .from_string(template)
@@ -94,6 +100,11 @@ def generate_data_source_sql(
 ) -> str:
     """Generates a SQL query for the specified data source."""
     template = DATA_SOURCE_QUERY.read_text()
+    macros_template = DATA_SOURCE_MACROS.read_text()
+
+    # using `from_string()` in Jinja doens't support include statements, so
+    # substituting them here manually
+    template = template.replace("{% include 'data_source_macros.j2' %}", macros_template)
     data_source_definition = config_collection.get_data_source_definition(data_source, platform)
 
     if data_source_definition is None:

--- a/metric_config_parser/sql.py
+++ b/metric_config_parser/sql.py
@@ -93,6 +93,7 @@ def generate_metrics_sql(
                     for slug, data_source in definition.spec.data_sources.definitions.items()
                     if platform == definition.platform
                 },
+                "select_fields": True,
             }
         )
     )
@@ -103,6 +104,7 @@ def generate_data_source_sql(
     data_source: str,
     platform: str,
     where: Optional[str] = None,
+    select_fields: bool = True,
 ) -> str:
     """Generates a SQL query for the specified data source."""
     template = DATA_SOURCE_QUERY.read_text()
@@ -134,6 +136,7 @@ def generate_data_source_sql(
                     if platform == definition.platform
                 },
                 "where": where,
+                "select_fields": select_fields,
             }
         )
     )

--- a/metric_config_parser/sql.py
+++ b/metric_config_parser/sql.py
@@ -87,6 +87,12 @@ def generate_metrics_sql(
                 "group_by": group_by,
                 "group_by_client_id": group_by_client_id,
                 "group_by_submission_date": group_by_submission_date,
+                "data_sources": {
+                    slug: data_source
+                    for definition in config_collection.definitions
+                    for slug, data_source in definition.spec.data_sources.definitions.items()
+                    if platform == definition.platform
+                },
             }
         )
     )
@@ -121,6 +127,12 @@ def generate_data_source_sql(
         .render(
             **{
                 "data_source": data_source_definition,
+                "data_sources": {
+                    slug: data_source
+                    for definition in config_collection.definitions
+                    for slug, data_source in definition.spec.data_sources.definitions.items()
+                    if platform == definition.platform
+                },
                 "where": where,
             }
         )

--- a/metric_config_parser/templates/data_source_macros.j2
+++ b/metric_config_parser/templates/data_source_macros.j2
@@ -1,0 +1,40 @@
+{% macro join(data_source, joined_data_source) -%}
+    {% if joined_data_source.relationship == 'one_to_one' -%}
+        INNER JOIN
+    {% elif joined_data_source.relationship == 'many_to_one' -%}
+        RIGHT JOIN
+    {% elif joined_data_source.relationship == 'one_to_many' -%}
+        LEFT JOIN
+    {% elif joined_data_source.relationship is None or joined_data_source.relationship == 'many_to_many' -%}
+        JOIN
+    {% endif %}
+    (
+        {{ data_source_query(joined_data_source) }}
+    ) AS {{ joined_data_source.name }} ON 
+    {% if joined_data_source.on_expression -%}
+        {{ joined_data_source.on_expression }}
+    {% else -%}
+        {{ data_source.name }}.{{ data_source.client_id_column }} ==
+        {{ joined_data_source.name }}.{{ joined_data_source.client_id_column }} AND
+        {{ data_source.name }}.{{ data_source.submission_date_column }} ==
+        {{ joined_data_source.name }}.{{ joined_data_source.submission_date_column }}
+    {% endif -%}
+{%- endmacro -%}
+
+{% macro data_source_query(data_source) -%}
+(
+    SELECT
+        *
+    FROM
+        {{ data_source.from_expression }} AS {{ data_source.name }}
+    {% if data_source.joins -%}
+        {% for joined_data_source in data_source.joins -%}
+            {{ join(data_source, joined_data_source) }}
+        {% endfor -%}
+    {% endif -%}
+    {% if where -%}
+    WHERE
+        {{ where }}
+    {% endif -%}
+)
+{%- endmacro -%}

--- a/metric_config_parser/templates/data_source_macros.j2
+++ b/metric_config_parser/templates/data_source_macros.j2
@@ -1,12 +1,10 @@
 {% macro join(data_source, joined_data_source_slug, joined_data_source) -%}
-    {% if 'relationship' not in joined_data_source or joined_data_source.relationship == 'many_to_many' -%}
-        JOIN
-    {% elif joined_data_source.relationship == 'one_to_one' -%}
-        INNER JOIN
-    {% elif joined_data_source.relationship == 'many_to_one' -%}
+    {% if 'relationship' in joined_data_source and joined_data_source.relationship == 'many_to_one' -%}
         RIGHT JOIN
-    {% elif joined_data_source.relationship == 'one_to_many' -%}
+    {% elif 'relationship' in joined_data_source and joined_data_source.relationship == 'one_to_many' -%}
         LEFT JOIN
+    {% else -%}
+        INNER JOIN
     {% endif -%}
     (
         {{ data_source_query(data_sources[joined_data_source_slug]) }}
@@ -22,23 +20,28 @@
 {%- endmacro -%}
 
 {% macro data_source_query(data_source) -%}
+{% if select_fields -%}
 (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            {{ data_source.from_expression }}
-        {% if where -%}
-        WHERE
-            {{ where }}
+    FROM
+{% endif -%}
+        (
+            SELECT
+                *
+            FROM
+                {{ data_source.from_expression }}
+            {% if where -%}
+            WHERE
+                {{ where }}
+            {% endif -%}
+        ) AS {{ data_source.name }}
+        {% if data_source.joins and data_source.client_id_column != 'NULL' -%}
+            {% for joined_data_source_slug, joined_data_source in data_source.joins.items() -%}
+                {{ join(data_source, joined_data_source_slug, joined_data_source) }}
+            {% endfor -%}
         {% endif -%}
-    ) AS {{ data_source.name }}
-    {% if data_source.joins -%}
-        {% for joined_data_source_slug, joined_data_source in data_source.joins.items() -%}
-            {{ join(data_source, joined_data_source_slug, joined_data_source) }}
-        {% endfor -%}
-    {% endif -%}
+{% if select_fields -%}
 )
+{% endif -%}
 {%- endmacro -%}

--- a/metric_config_parser/templates/data_source_macros.j2
+++ b/metric_config_parser/templates/data_source_macros.j2
@@ -1,23 +1,23 @@
-{% macro join(data_source, joined_data_source) -%}
-    {% if joined_data_source.relationship == 'one_to_one' -%}
+{% macro join(data_source, joined_data_source_slug, joined_data_source) -%}
+    {% if 'relationship' not in joined_data_source or joined_data_source.relationship == 'many_to_many' -%}
+        JOIN
+    {% elif joined_data_source.relationship == 'one_to_one' -%}
         INNER JOIN
     {% elif joined_data_source.relationship == 'many_to_one' -%}
         RIGHT JOIN
     {% elif joined_data_source.relationship == 'one_to_many' -%}
         LEFT JOIN
-    {% elif joined_data_source.relationship is None or joined_data_source.relationship == 'many_to_many' -%}
-        JOIN
-    {% endif %}
+    {% endif -%}
     (
-        {{ data_source_query(joined_data_source) }}
-    ) AS {{ joined_data_source.name }} ON 
-    {% if joined_data_source.on_expression -%}
+        {{ data_source_query(data_sources[joined_data_source_slug]) }}
+    ) ON 
+    {% if 'on_expression' in joined_data_source -%}
         {{ joined_data_source.on_expression }}
     {% else -%}
-        {{ data_source.name }}.{{ data_source.client_id_column }} ==
-        {{ joined_data_source.name }}.{{ joined_data_source.client_id_column }} AND
-        {{ data_source.name }}.{{ data_source.submission_date_column }} ==
-        {{ joined_data_source.name }}.{{ joined_data_source.submission_date_column }}
+        {{ data_source.name }}.{{ data_sources[data_source.name].client_id_column }} ==
+        {{ joined_data_source_slug }}.{{ data_sources[joined_data_source_slug].client_id_column }} AND
+        {{ data_source.name }}.{{ data_sources[data_source.name].submission_date_column }} ==
+        {{ joined_data_source_slug }}.{{ data_sources[joined_data_source_slug].submission_date_column }}
     {% endif -%}
 {%- endmacro -%}
 
@@ -25,16 +25,20 @@
 (
     SELECT
         *
-    FROM
-        {{ data_source.from_expression }} AS {{ data_source.name }}
+    FROM (
+        SELECT
+            *
+        FROM
+            {{ data_source.from_expression }}
+        {% if where -%}
+        WHERE
+            {{ where }}
+        {% endif -%}
+    ) AS {{ data_source.name }}
     {% if data_source.joins -%}
-        {% for joined_data_source in data_source.joins -%}
-            {{ join(data_source, joined_data_source) }}
+        {% for joined_data_source_slug, joined_data_source in data_source.joins.items() -%}
+            {{ join(data_source, joined_data_source_slug, joined_data_source) }}
         {% endfor -%}
-    {% endif -%}
-    {% if where -%}
-    WHERE
-        {{ where }}
     {% endif -%}
 )
 {%- endmacro -%}

--- a/metric_config_parser/templates/data_source_query.sql
+++ b/metric_config_parser/templates/data_source_query.sql
@@ -1,10 +1,8 @@
+{% include 'data_source_macros.j2' %}
+
 (
-    SELECT
-        *
-    FROM
-        {{ data_source.from_expression }}
-    {% if where -%}
-    WHERE
-        {{ where }}
-    {% endif -%}
+SELECT
+    *
+FROM
+    {{ data_source_query(data_source) }}
 )

--- a/metric_config_parser/templates/metrics_query.sql
+++ b/metric_config_parser/templates/metrics_query.sql
@@ -1,3 +1,5 @@
+{% include 'data_source_macros.j2' %}
+
 (
 {% for data_source_slug, data_source_info in metrics_per_data_source.items() -%}
 {{ "WITH" if loop.first else "" }} {{ data_source_slug }} AS (
@@ -14,12 +16,7 @@
         {% for metric in data_source_info["metrics"] -%}
         {{ metric.select_expression }} AS {{ metric.name }},
         {% endfor %}
-    FROM
-        {{ data_source_info["data_source"].from_expression }}
-    {% if where -%}
-    WHERE
-        {{ where }}
-    {% endif -%}
+    FROM {{ data_source_query(data_source_info["data_source"]) }}
     GROUP BY    
         {% for dimension, dimension_sql in group_by.items() -%}
         {{ dimension }}{{ "," if not loop.last or group_by_submission_date or group_by_client_id else "" }}

--- a/metric_config_parser/templates/metrics_query.sql
+++ b/metric_config_parser/templates/metrics_query.sql
@@ -17,7 +17,8 @@
         {{ metric.select_expression }} AS {{ metric.name }},
         {% endfor %}
     FROM {{ data_source_query(data_source_info["data_source"]) }}
-    GROUP BY    
+    {% if group_by != {} or group_by_submission_date or group_by_client_id -%}
+    GROUP BY
         {% for dimension, dimension_sql in group_by.items() -%}
         {{ dimension }}{{ "," if not loop.last or group_by_submission_date or group_by_client_id else "" }}
         {% endfor -%}
@@ -27,6 +28,7 @@
         {% if group_by_submission_date -%}
         submission_date
         {% endif %}
+    {% endif -%}
 ){{ "," if not loop.last else "" }}
 {% endfor -%}
 

--- a/metric_config_parser/tests/data/definitions/firefox_desktop.toml
+++ b/metric_config_parser/tests/data/definitions/firefox_desktop.toml
@@ -55,6 +55,10 @@ description = """
 
 [metrics.view_about_logins.statistics.bootstrap_mean]
 
+[metrics.joined_metric]
+data_source = "joined_baseline"
+select_expression = "SELECT 1"
+
 
 [data_sources]
 
@@ -82,6 +86,26 @@ from_expression = "mozdata.telemetry.events"
 experiments_column_type = "native"
 friendly_name = "Events"
 description = "Events Ping"
+
+[data_sources.joined_baseline]
+from_expression = "mozdata.telemetry.baseline"
+experiments_column_type = "native"
+friendly_name = "Baseline with events"
+description = "Baseline with events"
+client_id_column = "client_id"
+submission_date_column = "submission_date"
+
+[data_sources.joined_baseline.joins.events]
+on_expression = "joined_baseline.client_id = events.client_id"
+relationship = "many_to_many"
+
+[data_sources.multiple_joined_baseline]
+from_expression = "mozdata.telemetry.baseline"
+experiments_column_type = "native"
+friendly_name = "Baseline with events"
+description = "Baseline with events"
+
+[data_sources.multiple_joined_baseline.joins.joined_baseline]
 
 [segments]
 

--- a/metric_config_parser/tests/sql/test_generate_data_source.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_data_source.expected.sql
@@ -5,13 +5,15 @@ FROM
     (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            (SELECT 1)
-        WHERE
-            submission_date = '2023-01-01'
-        ) AS main
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                (SELECT 1)
+            WHERE
+                submission_date = '2023-01-01'
+            ) AS main
+        )
+
 )

--- a/metric_config_parser/tests/sql/test_generate_data_source.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_data_source.expected.sql
@@ -5,9 +5,13 @@ FROM
     (
     SELECT
         *
-    FROM
-        (SELECT 1) AS main
-    WHERE
-        submission_date = '2023-01-01'
+    FROM (
+        SELECT
+            *
+        FROM
+            (SELECT 1)
+        WHERE
+            submission_date = '2023-01-01'
+        ) AS main
     )
 )

--- a/metric_config_parser/tests/sql/test_generate_data_source.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_data_source.expected.sql
@@ -1,8 +1,13 @@
 (
+SELECT
+    *
+FROM
+    (
     SELECT
         *
     FROM
-        (SELECT 1)
+        (SELECT 1) AS main
     WHERE
         submission_date = '2023-01-01'
     )
+)

--- a/metric_config_parser/tests/sql/test_generate_data_source_with_join.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_data_source_with_join.expected.sql
@@ -5,30 +5,34 @@ FROM
     (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.baseline
-        WHERE
-            submission_date = '2023-01-01'
-        ) AS joined_baseline
-    JOIN
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.baseline
+            WHERE
+                submission_date = '2023-01-01'
+            ) AS joined_baseline
+        INNER JOIN
     (
         (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.events
-        WHERE
-            submission_date = '2023-01-01'
-        ) AS events
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.events
+            WHERE
+                submission_date = '2023-01-01'
+            ) AS events
+        )
+
     ) ON 
     joined_baseline.client_id = events.client_id
     
-        )
+            )
+
 )

--- a/metric_config_parser/tests/sql/test_generate_data_source_with_join.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_data_source_with_join.expected.sql
@@ -1,0 +1,34 @@
+(
+SELECT
+    *
+FROM
+    (
+    SELECT
+        *
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.baseline
+        WHERE
+            submission_date = '2023-01-01'
+        ) AS joined_baseline
+    JOIN
+    (
+        (
+    SELECT
+        *
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.events
+        WHERE
+            submission_date = '2023-01-01'
+        ) AS events
+    )
+    ) ON 
+    joined_baseline.client_id = events.client_id
+    
+        )
+)

--- a/metric_config_parser/tests/sql/test_generate_data_source_with_multi_join.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_data_source_with_multi_join.expected.sql
@@ -5,50 +5,56 @@ FROM
     (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.baseline
-        WHERE
-            submission_date = '2023-01-01'
-        ) AS multiple_joined_baseline
-    JOIN
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.baseline
+            WHERE
+                submission_date = '2023-01-01'
+            ) AS multiple_joined_baseline
+        INNER JOIN
     (
         (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.baseline
-        WHERE
-            submission_date = '2023-01-01'
-        ) AS joined_baseline
-    JOIN
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.baseline
+            WHERE
+                submission_date = '2023-01-01'
+            ) AS joined_baseline
+        INNER JOIN
     (
         (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.events
-        WHERE
-            submission_date = '2023-01-01'
-        ) AS events
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.events
+            WHERE
+                submission_date = '2023-01-01'
+            ) AS events
+        )
+
     ) ON 
     joined_baseline.client_id = events.client_id
     
-        )
+            )
+
     ) ON 
     multiple_joined_baseline.client_id ==
         joined_baseline.client_id AND
         multiple_joined_baseline.submission_date ==
         joined_baseline.submission_date
     
-        )
+            )
+
 )

--- a/metric_config_parser/tests/sql/test_generate_data_source_with_multi_join.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_data_source_with_multi_join.expected.sql
@@ -1,0 +1,54 @@
+(
+SELECT
+    *
+FROM
+    (
+    SELECT
+        *
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.baseline
+        WHERE
+            submission_date = '2023-01-01'
+        ) AS multiple_joined_baseline
+    JOIN
+    (
+        (
+    SELECT
+        *
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.baseline
+        WHERE
+            submission_date = '2023-01-01'
+        ) AS joined_baseline
+    JOIN
+    (
+        (
+    SELECT
+        *
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.events
+        WHERE
+            submission_date = '2023-01-01'
+        ) AS events
+    )
+    ) ON 
+    joined_baseline.client_id = events.client_id
+    
+        )
+    ) ON 
+    multiple_joined_baseline.client_id ==
+        joined_baseline.client_id AND
+        multiple_joined_baseline.submission_date ==
+        joined_baseline.submission_date
+    
+        )
+)

--- a/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
@@ -9,14 +9,18 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM
-        mozdata.telemetry.clients_daily AS clients_daily
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.clients_daily
+        ) AS clients_daily
     )
-    GROUP BY    
+    GROUP BY
         client_id,
         submission_date
         
-)
+    )
 SELECT
     clients_daily.client_id,
     clients_daily.submission_date,

--- a/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
@@ -6,8 +6,12 @@ WITH clients_daily AS (
         COALESCE(SUM(active_hours_sum), 0) AS active_hours,
         COUNT(submission_date) AS days_of_use,
         
+    FROM (
+    SELECT
+        *
     FROM
-        mozdata.telemetry.clients_daily
+        mozdata.telemetry.clients_daily AS clients_daily
+    )
     GROUP BY    
         client_id,
         submission_date

--- a/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_multiple_metrics.expected.sql
@@ -9,13 +9,15 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.clients_daily
-        ) AS clients_daily
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.clients_daily
+            ) AS clients_daily
+        )
+
     GROUP BY
         client_id,
         submission_date

--- a/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
@@ -8,13 +8,15 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.clients_daily
-        ) AS clients_daily
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.clients_daily
+            ) AS clients_daily
+        )
+
     GROUP BY
         client_id,
         submission_date

--- a/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
@@ -8,14 +8,18 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM
-        mozdata.telemetry.clients_daily AS clients_daily
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.clients_daily
+        ) AS clients_daily
     )
-    GROUP BY    
+    GROUP BY
         client_id,
         submission_date
         
-)
+    )
 SELECT
     clients_daily.client_id,
     clients_daily.submission_date,

--- a/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_single_metric.expected.sql
@@ -5,8 +5,12 @@ WITH clients_daily AS (
         submission_date AS submission_date,
         COALESCE(SUM(active_hours_sum), 0) AS active_hours,
         
+    FROM (
+    SELECT
+        *
     FROM
-        mozdata.telemetry.clients_daily
+        mozdata.telemetry.clients_daily AS clients_daily
+    )
     GROUP BY    
         client_id,
         submission_date

--- a/metric_config_parser/tests/sql/test_generate_query_with_joined_data_sources.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_joined_data_sources.expected.sql
@@ -7,32 +7,36 @@ WITH joined_baseline AS (
     FROM (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.baseline
-        WHERE
-            submission_date = '2023-01-01' AND normalized_channel = 'release'
-        ) AS joined_baseline
-    JOIN
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.baseline
+            WHERE
+                submission_date = '2023-01-01' AND normalized_channel = 'release'
+            ) AS joined_baseline
+        INNER JOIN
     (
         (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.events
-        WHERE
-            submission_date = '2023-01-01' AND normalized_channel = 'release'
-        ) AS events
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.events
+            WHERE
+                submission_date = '2023-01-01' AND normalized_channel = 'release'
+            ) AS events
+        )
+
     ) ON 
     joined_baseline.client_id = events.client_id
     
-        )
+            )
+
     GROUP BY
         client_id
         

--- a/metric_config_parser/tests/sql/test_generate_query_with_joined_data_sources.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_joined_data_sources.expected.sql
@@ -1,0 +1,46 @@
+(
+WITH joined_baseline AS (
+    SELECT
+        client_id AS client_id,
+        SELECT 1 AS joined_metric,
+        
+    FROM (
+    SELECT
+        *
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.baseline
+        WHERE
+            submission_date = '2023-01-01' AND normalized_channel = 'release'
+        ) AS joined_baseline
+    JOIN
+    (
+        (
+    SELECT
+        *
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.events
+        WHERE
+            submission_date = '2023-01-01' AND normalized_channel = 'release'
+        ) AS events
+    )
+    ) ON 
+    joined_baseline.client_id = events.client_id
+    
+        )
+    GROUP BY
+        client_id
+        
+    )
+SELECT
+    joined_baseline.client_id,
+    joined_metric,
+    
+FROM
+    joined_baseline
+)

--- a/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
@@ -8,10 +8,14 @@ WITH clients_daily AS (
         COALESCE(SUM(active_hours_sum), 0) AS active_hours,
         COUNT(submission_date) AS days_of_use,
         
+    FROM (
+    SELECT
+        *
     FROM
-        mozdata.telemetry.clients_daily
+        mozdata.telemetry.clients_daily AS clients_daily
     WHERE
         submission_date = '2023-01-01' AND normalized_channel = 'release'
+    )
     GROUP BY    
         build_id,
         sample_id,
@@ -30,15 +34,19 @@ WITH clients_daily AS (
         AND event_string_value = '{experiment_slug}'
      ), FALSE) AS unenroll,
         
+    FROM (
+    SELECT
+        *
     FROM
         (
     SELECT
         *
     FROM mozdata.telemetry.events
     WHERE event_category = 'normandy'
-)
+) AS normandy_events
     WHERE
         submission_date = '2023-01-01' AND normalized_channel = 'release'
+    )
     GROUP BY    
         build_id,
         sample_id,
@@ -56,10 +64,14 @@ WITH clients_daily AS (
             AND event_category = 'pwmgr'
          ), FALSE) AS view_about_logins,
         
+    FROM (
+    SELECT
+        *
     FROM
-        mozdata.telemetry.events
+        mozdata.telemetry.events AS events
     WHERE
         submission_date = '2023-01-01' AND normalized_channel = 'release'
+    )
     GROUP BY    
         build_id,
         sample_id,

--- a/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
@@ -11,18 +11,22 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM
-        mozdata.telemetry.clients_daily AS clients_daily
-    WHERE
-        submission_date = '2023-01-01' AND normalized_channel = 'release'
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.clients_daily
+        WHERE
+            submission_date = '2023-01-01' AND normalized_channel = 'release'
+        ) AS clients_daily
     )
-    GROUP BY    
+    GROUP BY
         build_id,
         sample_id,
         client_id,
         submission_date
         
-),
+    ),
  normandy_events AS (
     SELECT
         client_id AS client_id,
@@ -37,23 +41,27 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM
-        (
+    FROM (
+        SELECT
+            *
+        FROM
+            (
     SELECT
         *
     FROM mozdata.telemetry.events
     WHERE event_category = 'normandy'
-) AS normandy_events
-    WHERE
-        submission_date = '2023-01-01' AND normalized_channel = 'release'
+)
+        WHERE
+            submission_date = '2023-01-01' AND normalized_channel = 'release'
+        ) AS normandy_events
     )
-    GROUP BY    
+    GROUP BY
         build_id,
         sample_id,
         client_id,
         submission_date
         
-),
+    ),
  events AS (
     SELECT
         client_id AS client_id,
@@ -67,18 +75,22 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM
-        mozdata.telemetry.events AS events
-    WHERE
-        submission_date = '2023-01-01' AND normalized_channel = 'release'
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.events
+        WHERE
+            submission_date = '2023-01-01' AND normalized_channel = 'release'
+        ) AS events
     )
-    GROUP BY    
+    GROUP BY
         build_id,
         sample_id,
         client_id,
         submission_date
         
-)
+    )
 SELECT
     clients_daily.client_id,
     clients_daily.submission_date,

--- a/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_multiple_metrics_different_data_sources.expected.sql
@@ -11,15 +11,17 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.clients_daily
-        WHERE
-            submission_date = '2023-01-01' AND normalized_channel = 'release'
-        ) AS clients_daily
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.clients_daily
+            WHERE
+                submission_date = '2023-01-01' AND normalized_channel = 'release'
+            ) AS clients_daily
+        )
+
     GROUP BY
         build_id,
         sample_id,
@@ -41,20 +43,22 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            (
+    FROM
+(
+            SELECT
+                *
+            FROM
+                (
     SELECT
         *
     FROM mozdata.telemetry.events
     WHERE event_category = 'normandy'
 )
-        WHERE
-            submission_date = '2023-01-01' AND normalized_channel = 'release'
-        ) AS normandy_events
-    )
+            WHERE
+                submission_date = '2023-01-01' AND normalized_channel = 'release'
+            ) AS normandy_events
+        )
+
     GROUP BY
         build_id,
         sample_id,
@@ -75,15 +79,17 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.events
-        WHERE
-            submission_date = '2023-01-01' AND normalized_channel = 'release'
-        ) AS events
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.events
+            WHERE
+                submission_date = '2023-01-01' AND normalized_channel = 'release'
+            ) AS events
+        )
+
     GROUP BY
         build_id,
         sample_id,

--- a/metric_config_parser/tests/sql/test_generate_query_with_parameters.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_parameters.expected.sql
@@ -11,18 +11,22 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM
-        mozdata.telemetry.clients_daily AS clients_daily
-    WHERE
-        submission_date = '2023-01-01' AND normalized_channel = 'release'
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.clients_daily
+        WHERE
+            submission_date = '2023-01-01' AND normalized_channel = 'release'
+        ) AS clients_daily
     )
-    GROUP BY    
+    GROUP BY
         build_id,
         sample_id,
         client_id,
         submission_date
         
-)
+    )
 SELECT
     clients_daily.client_id,
     clients_daily.submission_date,

--- a/metric_config_parser/tests/sql/test_generate_query_with_parameters.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_parameters.expected.sql
@@ -8,10 +8,14 @@ WITH clients_daily AS (
         COALESCE(SUM(active_hours_sum), 0) AS active_hours,
         COUNT(submission_date) AS days_of_use,
         
+    FROM (
+    SELECT
+        *
     FROM
-        mozdata.telemetry.clients_daily
+        mozdata.telemetry.clients_daily AS clients_daily
     WHERE
         submission_date = '2023-01-01' AND normalized_channel = 'release'
+    )
     GROUP BY    
         build_id,
         sample_id,

--- a/metric_config_parser/tests/sql/test_generate_query_with_parameters.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_with_parameters.expected.sql
@@ -11,15 +11,17 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.clients_daily
-        WHERE
-            submission_date = '2023-01-01' AND normalized_channel = 'release'
-        ) AS clients_daily
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.clients_daily
+            WHERE
+                submission_date = '2023-01-01' AND normalized_channel = 'release'
+            ) AS clients_daily
+        )
+
     GROUP BY
         build_id,
         sample_id,

--- a/metric_config_parser/tests/sql/test_generate_query_without_client_id.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_without_client_id.expected.sql
@@ -7,15 +7,19 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM
-        mozdata.telemetry.clients_daily AS clients_daily
-    WHERE
-        submission_date = '2023-01-01' AND normalized_channel = 'release'
+    FROM (
+        SELECT
+            *
+        FROM
+            mozdata.telemetry.clients_daily
+        WHERE
+            submission_date = '2023-01-01' AND normalized_channel = 'release'
+        ) AS clients_daily
     )
-    GROUP BY    
+    GROUP BY
         build_id
         
-)
+    )
 SELECT
     clients_daily.build_id AS build_id,
     active_hours,

--- a/metric_config_parser/tests/sql/test_generate_query_without_client_id.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_without_client_id.expected.sql
@@ -7,15 +7,17 @@ WITH clients_daily AS (
     FROM (
     SELECT
         *
-    FROM (
-        SELECT
-            *
-        FROM
-            mozdata.telemetry.clients_daily
-        WHERE
-            submission_date = '2023-01-01' AND normalized_channel = 'release'
-        ) AS clients_daily
-    )
+    FROM
+(
+            SELECT
+                *
+            FROM
+                mozdata.telemetry.clients_daily
+            WHERE
+                submission_date = '2023-01-01' AND normalized_channel = 'release'
+            ) AS clients_daily
+        )
+
     GROUP BY
         build_id
         

--- a/metric_config_parser/tests/sql/test_generate_query_without_client_id.expected.sql
+++ b/metric_config_parser/tests/sql/test_generate_query_without_client_id.expected.sql
@@ -4,10 +4,14 @@ WITH clients_daily AS (
         build_id AS build_id,
         COALESCE(SUM(active_hours_sum), 0) AS active_hours,
         
+    FROM (
+    SELECT
+        *
     FROM
-        mozdata.telemetry.clients_daily
+        mozdata.telemetry.clients_daily AS clients_daily
     WHERE
         submission_date = '2023-01-01' AND normalized_channel = 'release'
+    )
     GROUP BY    
         build_id
         

--- a/metric_config_parser/tests/test_config.py
+++ b/metric_config_parser/tests/test_config.py
@@ -16,10 +16,10 @@ from metric_config_parser.config import (
     DefinitionConfig,
     Outcome,
 )
+from metric_config_parser.data_source import DataSourceJoinRelationship
 from metric_config_parser.errors import DefinitionNotFound
 from metric_config_parser.metric import MetricLevel
 from metric_config_parser.outcome import OutcomeSpec
-from metric_config_parser.data_source import DataSourceJoinRelationship
 
 TEST_DIR = Path(__file__).parent
 
@@ -588,7 +588,7 @@ class TestConfigIntegration:
             experiments_column_type = "simple"
 
             [data_sources.baseline.joins.metrics]
-            
+
             [data_sources.metrics.joins.baseline]
             """
         )

--- a/metric_config_parser/tests/test_sql.py
+++ b/metric_config_parser/tests/test_sql.py
@@ -92,3 +92,38 @@ def test_data_source_not_found(config_collection):
         config_collection.get_data_source_sql(
             data_source="non-existing", platform="firefox_desktop"
         )
+
+
+def test_data_source_with_join(config_collection):
+    assert (
+        config_collection.get_data_source_sql(
+            data_source="joined_baseline",
+            platform="firefox_desktop",
+            where="submission_date = '2023-01-01'",
+        )
+        == (TEST_DATA / "test_generate_data_source_with_join.expected.sql").read_text()
+    )
+
+
+def test_data_source_with_multiple_join(config_collection):
+    assert (
+        config_collection.get_data_source_sql(
+            data_source="multiple_joined_baseline",
+            platform="firefox_desktop",
+            where="submission_date = '2023-01-01'",
+        )
+        == (TEST_DATA / "test_generate_data_source_with_multi_join.expected.sql").read_text()
+    )
+
+
+def test_metric_with_joined_data_source(config_collection):
+    assert (
+        config_collection.get_metrics_sql(
+            metrics=["joined_metric"],
+            platform="firefox_desktop",
+            where="submission_date = '2023-01-01' AND normalized_channel = 'release'",
+            group_by_client_id=True,
+            group_by_submission_date=False,
+        )
+        == (TEST_DATA / "test_generate_query_with_joined_data_sources.expected.sql").read_text()
+    )


### PR DESCRIPTION
This adds support for joining data sources in metric hub:

```toml
[data_sources.baseline]
select_expression = "mozdata.telemetry.baseline"

[data_sources.events]
select_expression = "mozdata.telemetry.events"

[data_sources.events.joins.baseline]  # the baseline data source gets joined on to the events data source
relationship = "many_to_many"
on_expression = "baseline.submission_date = events.submission_date AND baseline.client_id = events.client_id"
```

The `generate_..._sql` methods that `metric-config-parser` provides do take this configuration into consideration. It will however be ignored in jetstream at the moment since `mozanalysis` doesn't use these `generate_..._sql` methods. Supporting joins there is tbd